### PR TITLE
Fix wrong variable intent

### DIFF
--- a/src/contselfenergy.F90
+++ b/src/contselfenergy.F90
@@ -383,7 +383,7 @@ contains
     complex(dp), intent(in) :: Ec
     Type(Tnegf), intent(inout) :: pnegf
     real(dp), intent(out) :: ncyc
-    Type(z_DNS), Dimension(MAXNCONT), intent(in) :: Tlc, Tcl
+    Type(z_DNS), Dimension(MAXNCONT), intent(inout) :: Tlc, Tcl
     Type(z_DNS), Dimension(MAXNCONT), intent(out) :: SelfEneR, GS
 
 

--- a/src/integrations.F90
+++ b/src/integrations.F90
@@ -1803,7 +1803,8 @@ contains
     implicit none
 
     real(dp) :: integrate_el
-    real(dp), intent(in) :: mu1,mu2,emin,emax,estep
+    real(dp), intent(inout) :: mu1, mu2
+    real(dp), intent(in) :: emin,emax,estep
     real(dp), dimension(:), intent(in) :: TUN_TOT
     real(dp), intent(in) :: kT1, kT2
     real(dp), intent(in) :: spin_g

--- a/src/iterative_dns.F90
+++ b/src/iterative_dns.F90
@@ -120,7 +120,7 @@ CONTAINS
     type(Tnegf), intent(inout) :: negf
     complex(dp), intent(in) :: E
     type(z_DNS), dimension(:), intent(in) :: SelfEneR
-    type(z_DNS), dimension(:), intent(in) :: Tlc, Tcl, gsurfR
+    type(z_DNS), dimension(:), intent(inout) :: Tlc, Tcl, gsurfR
     type(z_CSR), intent(out) :: A
     integer, intent(in) :: outer
 


### PR DESCRIPTION
Bug may lead to unexpected results, as the compiler is in theory allowed to make a copy of intent(in) variables at entry, whithout copy-back at exit (NAG compiled binary throws run-time errror in DEBUG mode). Unfortunately, missing intent attributes in sparsekit prevent the detection of such errors at compile time.