### PR TITLE
Cmake api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,14 @@ set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH
 set(INSTALL_MOD_DIR "${CMAKE_INSTALL_PREFIX}/include/libnegf/modfiles" CACHE PATH
   "Installation directory for Fortran module files")
 
+set(INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include/libnegf" CACHE PATH
+  "Installation directory for C and C++ header files")
+
 option(BUILD_SHARED_LIBS "Whether the library should be shared" FALSE)
 
-option(INSTALL_INCLUDE_FILES "Whether module files should be installed" TRUE)
+option(INSTALL_INCLUDE_FILES "Whether module files and headers should be installed" TRUE)
+
+option(BUILD_TESTING "Whether the tests should be built" FALSE)
 
 if(WITH_MPI)
   find_package(MPI REQUIRED)
@@ -30,3 +35,8 @@ endif()
 add_subdirectory(ext_sparskit)
 add_subdirectory(ext_system)
 add_subdirectory(src)
+add_subdirectory(src/api)
+if(BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,30 @@
+Compiling and installing
+========================
+
+Cmake installation
+------------------
+
+libNEGF can be installed using `cmake`. The suggested way of installing
+is performing an out-of-source build in a temporary directory, e.g. from
+the base directory:
+
+```
+mkdir build
+cd build 
+cmake ..
+make && make install
+```
+
+For a list of available configuration options type
+
+```
+cmake .. -LAH
+```
+
+If you want to build also the tests, enable the `BUILD_TESTING` option:
+
+```
+cmake .. -DBUILD_TESTING=TRUE 
+make && make test
+```
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,6 @@ set(sources-f90
   api/libnegfAPICommon.f90
   api/libnegf_api.f90)
 
-
 #execute_process(COMMAND git describe OUTPUT_VARIABLE gitrevision)
 set(gitrevision "000")
 string(TIMESTAMP compdate "%Y-%m-%d")

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,0 +1,37 @@
+set(negf-interface-headers)
+set(all-header-deps libnegf_api.f90 bind_fortran)
+
+add_custom_target(negf-c-binding ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libnegf.h)
+set(c-header-binding-deps binding/map_negf_c.txt binding/begin_c.txt binding/end_c.txt)
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libnegf.h
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${all-header-deps} ${CMAKE_CURRENT_SOURCE_DIR}/${c-header-binding-deps}
+    COMMENT "Generating C header"
+    COMMAND ./bind_fortran -f c -m binding/map_negf_c.txt -b binding/begin_c.txt -n -t -e binding/end_c.txt libnegf_api.f90 > ${CMAKE_CURRENT_BINARY_DIR}/libnegf.h
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+list(APPEND negf-interface-headers ${CMAKE_CURRENT_BINARY_DIR}/libnegf.h)
+
+add_custom_target(negf-cpp-binding ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libnegf.hpp)
+set(cpp-header-binding-deps binding/map_negf_cpp_wrapped.txt binding/begin_cpp_wrapped.txt binding/end_cpp_wrapped.txt)
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libnegf.hpp
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${all-header-deps} ${CMAKE_CURRENT_SOURCE_DIR}/${cpp-header-binding-deps}
+    COMMENT "Generating C++ header"
+    COMMAND ./bind_fortran -f c++ -m binding/map_negf_cpp_wrapped.txt -b binding/begin_cpp_wrapped.txt -t -e binding/end_cpp_wrapped.txt libnegf_api.f90 > ${CMAKE_CURRENT_BINARY_DIR}/libnegf.hpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+list(APPEND negf-interface-headers ${CMAKE_CURRENT_BINARY_DIR}/libnegf.hpp)
+
+add_custom_target(negf-all-headers ALL DEPENDS negf-c-binding negf-cpp-binding ${CMAKE_CURRENT_BINARY_DIR}/lnParams.h)
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lnParams.h
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/lnParams.h
+    COMMENT "Copying lnParams.h"
+    COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/lnParams.h ${CMAKE_CURRENT_BINARY_DIR}/lnParams.h
+)
+list(APPEND negf-interface-headers ${CMAKE_CURRENT_BINARY_DIR}/lnParams.h)
+
+if(INSTALL_INCLUDE_FILES)
+    install(FILES ${negf-interface-headers} DESTINATION ${INSTALL_INCLUDE_DIR})
+endif()

--- a/src/api/libnegf_api.f90
+++ b/src/api/libnegf_api.f90
@@ -166,6 +166,21 @@ subroutine negf_init_structure(handler, ncont, contend, surfend, npl, plend, cbl
 
 end subroutine negf_init_structure
 
+!!* Pass contacts
+subroutine negf_init_contacts(handler, ncont) bind(c)
+  use iso_c_binding, only : c_int  ! if:mod:use
+  use libnegfAPICommon  ! if:mod:use
+  use libnegf           ! if:mod:use
+  implicit none
+  integer(c_int), intent(inout) :: handler(DAC_handlerSize)  ! if:var:inout
+  integer(c_int), intent(in), value :: ncont ! if:var:inout
+  type(NEGFpointers) :: LIB
+
+  LIB = transfer(handler, LIB)
+
+  call init_contacts(LIB%pNEGF, ncont)
+
+end subroutine negf_init_contacts
 
 !!* Passing parameters
 subroutine negf_set_params(handler, params) bind(c)

--- a/src/integrations.F90
+++ b/src/integrations.F90
@@ -1819,15 +1819,15 @@ contains
     destep=1.0d10
     Nstep=NINT((emax-emin)/estep);
 
-    !We set a minimum possible value T = 0.01 K to avoid
+    !We set a minimum possible value T = 1.0 K to avoid
     !numerical issues
-    if (kT1 < 0.01_dp*Kb) then
-      kbT1 = Kb*0.01_dp
+    if (kT1 < 1.0_dp*Kb) then
+      kbT1 = Kb*1.0_dp
     else
       kbT1 = kT1
     endif
-    if (kT2 < 0.01_dp*Kb) then
-      kbT2 = Kb*0.01_dp
+    if (kT2 < 1.0_dp*Kb) then
+      kbT2 = Kb*1.0_dp
     else
       kbT2 = kT2
     endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,32 @@
+# List of active tets. Each test indicates a subdirectory. 
+set(test-directories 
+        c_int 
+        c_int_file 
+        f90int 
+        f90int_file
+        )
+
+# Make BLAS and LAPACK available to be linked in the tests.
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
+set(libs ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+
+# Define a function wich copies over the content of the tests.
+# This is used to support out-of-source build, as the test
+# directory contain input files which we don't want to specify.
+function(transfer_test_data testname)
+    if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}") 
+        add_custom_target(${testname}-data-transfer)   
+    else()
+        add_custom_target(
+            ${testname}-data-transfer
+            COMMENT "Copying ${CMAKE_CURRENT_SOURCE_DIR} for out-of-source build."
+            COMMAND cp -f ${CMAKE_CURRENT_SOURCE_DIR}/* ${CMAKE_CURRENT_BINARY_DIR}/)
+    endif()
+    add_dependencies(${testname} ${testname}-data-transfer)
+endfunction()
+
+
+foreach(test-directory IN LISTS test-directories)
+    add_subdirectory(${test-directory})
+endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(test-directories
         c_int_file 
         f90int 
         f90int_file
+        f90elph_deph
         )
 
 # Make BLAS and LAPACK available to be linked in the tests.
@@ -24,6 +25,24 @@ function(transfer_test_data testname)
             COMMAND cp -f ${CMAKE_CURRENT_SOURCE_DIR}/* ${CMAKE_CURRENT_BINARY_DIR}/)
     endif()
     add_dependencies(${testname} ${testname}-data-transfer)
+endfunction()
+
+# A function to setup C tests.
+function(setup_c_test testname source)
+    add_executable(${testname} ${source})
+    transfer_test_data(${testname})
+    target_link_libraries(${testname} negf sparskit ${libs})
+    target_include_directories(${testname} PRIVATE ${CMAKE_BINARY_DIR}/src/api)
+    add_test(${testname} ${testname})
+endfunction()
+
+# A function to setup F90 tests.
+function(setup_f90_test testname source)
+    add_executable(${testname} ${source})
+    transfer_test_data(${testname})
+    target_link_libraries(${testname} negf sparskit ${libs})
+    target_include_directories(${testname} PRIVATE ${BUILD_MOD_DIR})
+    add_test(${testname} ${testname})
 endfunction()
 
 

--- a/tests/c_int/CMakeLists.txt
+++ b/tests/c_int/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(c_int hello.c)
+transfer_test_data(c_int)
+target_link_libraries(c_int negf sparskit ${libs})
+target_include_directories(c_int PRIVATE ${CMAKE_BINARY_DIR}/src/api)
+add_test(c_int c_int)

--- a/tests/c_int/CMakeLists.txt
+++ b/tests/c_int/CMakeLists.txt
@@ -1,5 +1,1 @@
-add_executable(c_int hello.c)
-transfer_test_data(c_int)
-target_link_libraries(c_int negf sparskit ${libs})
-target_include_directories(c_int PRIVATE ${CMAKE_BINARY_DIR}/src/api)
-add_test(c_int c_int)
+setup_c_test(c_int hello.c)

--- a/tests/c_int/hello.c
+++ b/tests/c_int/hello.c
@@ -26,15 +26,18 @@ int main()
   negf_init(hand);
   negf_read_hs(hand, &realmat[0], &imagmat[0], 0);
   negf_set_s_id(hand, 100);
+  negf_init_contacts(hand, 2);
   negf_init_structure(hand, 2, &contend[0], &surfend[0], 1, &plend[0], &cblk[0]);
 
-  //Set parameters  
+  //Set parameters
   negf_get_params(hand, &params);
   params.emin = -3.0;
   params.emax = 3.0;
   params.estep = 0.01;
+  params.kbt_t[0] = 0.001;
+  params.kbt_t[1] = 0.001;
   negf_set_params(hand, &params);
- 
+
   //Set ldos parameters
   negf_init_ldos(hand, 1);
   negf_set_ldos_intervals(hand, 1, &ldos_start[0], &ldos_end[0]);

--- a/tests/c_int_file/CMakeLists.txt
+++ b/tests/c_int_file/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(c_int_file hello.c)
+transfer_test_data(c_int_file)
+target_link_libraries(c_int_file negf sparskit ${libs})
+target_include_directories(c_int_file PRIVATE ${CMAKE_BINARY_DIR}/src/api)
+add_test(c_int_file c_int_file)

--- a/tests/c_int_file/CMakeLists.txt
+++ b/tests/c_int_file/CMakeLists.txt
@@ -1,5 +1,1 @@
-add_executable(c_int_file hello.c)
-transfer_test_data(c_int_file)
-target_link_libraries(c_int_file negf sparskit ${libs})
-target_include_directories(c_int_file PRIVATE ${CMAKE_BINARY_DIR}/src/api)
-add_test(c_int_file c_int_file)
+setup_c_test(c_int_file hello.c)

--- a/tests/c_int_file/hello.c
+++ b/tests/c_int_file/hello.c
@@ -20,6 +20,7 @@ int main()
   printf("Initializing libNEGF \n");
   negf_init_session(hand);
   negf_init(hand);
+  negf_init_contacts(hand, 2);
   negf_read_input(hand);
   negf_solve_landauer(hand);
   negf_write_tunneling_and_dos(hand);

--- a/tests/f90elph_deph/CMakeLists.txt
+++ b/tests/f90elph_deph/CMakeLists.txt
@@ -1,0 +1,1 @@
+setup_f90_test(f90elph_deph hello.F90)

--- a/tests/f90int/CMakeLists.txt
+++ b/tests/f90int/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(f90int hello.F90)
+transfer_test_data(f90int)
+target_link_libraries(f90int negf sparskit ${libs})
+target_include_directories(f90int PRIVATE ${BUILD_MOD_DIR})
+add_test(f90int f90int)

--- a/tests/f90int/CMakeLists.txt
+++ b/tests/f90int/CMakeLists.txt
@@ -1,5 +1,1 @@
-add_executable(f90int hello.F90)
-transfer_test_data(f90int)
-target_link_libraries(f90int negf sparskit ${libs})
-target_include_directories(f90int PRIVATE ${BUILD_MOD_DIR})
-add_test(f90int f90int)
+setup_f90_test(f90int hello.F90)

--- a/tests/f90int/hello.F90
+++ b/tests/f90int/hello.F90
@@ -1,9 +1,9 @@
 !!--------------------------------------------------------------------------!
 !! libNEGF: a general library for Non-Equilibrium Green's functions.        !
 !! Copyright (C) 2012                                                       !
-!!                                                                          ! 
+!!                                                                          !
 !! This file is part of libNEGF: a library for                              !
-!! Non Equilibrium Green's Function calculation                             ! 
+!! Non Equilibrium Green's Function calculation                             !
 !!                                                                          !
 !! Developers: Alessandro Pecchia, Gabriele Penazzi                         !
 !! Former Conctributors: Luca Latessa, Aldo Di Carlo                        !
@@ -15,7 +15,7 @@
 !!                                                                          !
 !!  You should have received a copy of the GNU Lesser General Public        !
 !!  License along with libNEGF.  If not, see                                !
-!!  <http://www.gnu.org/licenses/>.                                         !  
+!!  <http://www.gnu.org/licenses/>.                                         !
 !!--------------------------------------------------------------------------!
 
 program hello
@@ -29,7 +29,8 @@ program hello
   Type(Tnegf), pointer :: pnegf
   Type(lnParams) :: params
   integer, allocatable :: surfend(:), contend(:), plend(:), cblk(:)
-  real(kind(1.d0)), allocatable :: mu(:), kt(:), energies(:), transmission(:,:)
+  real(kind(1.d0)), allocatable :: mu(:), kt(:)
+  real(kind(1.d0)), dimension(:,:), pointer :: transmission
 
   surfend = [60,80]
   contend = [80,100]
@@ -43,21 +44,22 @@ program hello
   write(*,*) 'Libnegf hello world'
   write(*,*) 'Init...'
   call init_negf(pnegf)
+  call init_contacts(pnegf, 2)
   write(*,*) 'Import Hamiltonian'
   call read_HS(pnegf, "H_real.dat", "H_imm.dat", 0)
   call set_S_id(pnegf, 100)
   call init_structure(pnegf, 2, contend, surfend, 1, plend, cblk)
-  
+
   ! Here we set the parameters, only the ones different from default
   call get_params(pnegf, params)
   params%Emin = -3.d0
   params%Emax = 3.d0
   params%Estep = 1.d-2
   call set_params(pnegf, params)
-  
+
   write(*,*) 'Compute landauer tunneling and current'
   call compute_current(pnegf)
-  call get_transmission(pnegf, energies, transmission)
+  call associate_transmission(pnegf, transmission)
   ! The above passes the transmission, but we write to file for debug
   call write_tunneling_and_dos(pnegf)
   write(*,*) 'Destroy negf'

--- a/tests/f90int_file/CMakeLists.txt
+++ b/tests/f90int_file/CMakeLists.txt
@@ -1,5 +1,1 @@
-add_executable(f90int_file hello.F90)
-transfer_test_data(f90int_file)
-target_link_libraries(f90int_file negf sparskit ${libs})
-target_include_directories(f90int_file PRIVATE ${BUILD_MOD_DIR})
-add_test(f90int_file f90int_file)
+setup_f90_test(f90int_file hello.F90)

--- a/tests/f90int_file/CMakeLists.txt
+++ b/tests/f90int_file/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(f90int_file hello.F90)
+transfer_test_data(f90int_file)
+target_link_libraries(f90int_file negf sparskit ${libs})
+target_include_directories(f90int_file PRIVATE ${BUILD_MOD_DIR})
+add_test(f90int_file f90int_file)

--- a/tests/f90int_file/hello.F90
+++ b/tests/f90int_file/hello.F90
@@ -1,9 +1,9 @@
 !!--------------------------------------------------------------------------!
 !! libNEGF: a general library for Non-Equilibrium Green's functions.        !
 !! Copyright (C) 2012                                                       !
-!!                                                                          ! 
+!!                                                                          !
 !! This file is part of libNEGF: a library for                              !
-!! Non Equilibrium Green's Function calculation                             ! 
+!! Non Equilibrium Green's Function calculation                             !
 !!                                                                          !
 !! Developers: Alessandro Pecchia, Gabriele Penazzi                         !
 !! Former Conctributors: Luca Latessa, Aldo Di Carlo                        !
@@ -15,7 +15,7 @@
 !!                                                                          !
 !!  You should have received a copy of the GNU Lesser General Public        !
 !!  License along with libNEGF.  If not, see                                !
-!!  <http://www.gnu.org/licenses/>.                                         !  
+!!  <http://www.gnu.org/licenses/>.                                         !
 !!--------------------------------------------------------------------------!
 
 program hello
@@ -27,18 +27,19 @@ program hello
 
   Type(Tnegf), target :: negf
   Type(Tnegf), pointer :: pnegf
-  real(kind(1.d0)), allocatable :: energies(:), transmission(:,:)
+  real(kind(1.d0)), dimension(:,:), pointer :: transmission
 
   pnegf => negf
 
   write(*,*) 'Libnegf hello world'
   write(*,*) 'Init...'
   call init_negf(pnegf)
+  call init_contacts(pnegf, 2)
   call read_negf_in(negf)
-  
+
   write(*,*) 'Compute landauer tunneling and current'
   call compute_current(pnegf)
-  call get_transmission(pnegf, energies, transmission)
+  call associate_transmission(pnegf, transmission)
   ! The above passes the transmission, but we write to file for debug
   call write_tunneling_and_dos(pnegf)
   write(*,*) 'Release libnegf'


### PR DESCRIPTION
Extension of previous cmake PR. Includes include:
- Generation of C and C++ headers
- Compilation and execution of tests via cmake
- Add missing method in the API

Known issues:
- Tests only work in serial, MPI not supported yet

Possible improvement:
- Populate testsuite automatically, now you have to add a `CMakeLists.txt` in the test directory and the test name in the `tests/CMakeLists.txt`
- Control API compilation via flag. Maybe we don't need it always, we can split F90 interface and test compilation and the generic C/C++/F90 interface and test. This can be done very easily. 
