### PR TITLE
Contact init fix

### DIFF
--- a/src/api/lnParams.h
+++ b/src/api/lnParams.h
@@ -24,7 +24,7 @@ struct lnparams {
   double mu_p[MAXNCONT];
   double mu[MAXNCONT];
   double contact_dos[MAXNCONT];
-  int fictcont[MAXNCONT];
+  _Bool fictcont[MAXNCONT];
   double kbt_dm[MAXNCONT];
   double kbt_t[MAXNCONT];
   int np_n[2];

--- a/src/libnegf.F90
+++ b/src/libnegf.F90
@@ -560,7 +560,7 @@ contains
     params%DorE = negf%DorE
     params%min_or_max = negf%min_or_max
     params%isSid = negf%isSid
-     
+
   end subroutine get_params
 
   !> Assign parameters to libnegf
@@ -572,7 +572,7 @@ contains
 
     negf%verbose = params%verbose
     negf%readOldDM_SGFs = params%readOldDM_SGFs
-    negf%readOldT_SGFs = params%readOldT_SGFs 
+    negf%readOldT_SGFs = params%readOldT_SGFs
     negf%g_spin = params%g_spin
     negf%delta = params%delta
     negf%dos_delta = params%dos_delta
@@ -677,7 +677,7 @@ contains
         end if
       end do
       deallocate(negf%ldos)
-    end if  
+    end if
     allocate(negf%ldos(nldos))
     negf%nldos = nldos
 
@@ -691,7 +691,7 @@ contains
     do i=1, size(ldos)
       if (allocated(ldos(i)%indexes)) then
         call log_deallocate(ldos(i)%indexes)
-      end if  
+      end if
     end do
 
     deallocate(ldos)
@@ -733,7 +733,7 @@ contains
 
     if (.not.allocated(negf%ldos(ildos)%indexes)) then
        call log_allocate(negf%ldos(ildos)%indexes, size(idx))
-    end if   
+    end if
     negf%ldos(ildos)%indexes = idx
 
   end subroutine set_ldos_indexes
@@ -780,7 +780,7 @@ contains
   subroutine set_readOldDMsgf(negf,flag)
     type(Tnegf) :: negf
     integer :: flag !between 0:2
-    
+
     negf%ReadOldDM_SGFs = flag
   end subroutine set_readOldDMsgf
 
@@ -788,7 +788,7 @@ contains
   subroutine set_readOldTsgf(negf,flag)
     type(Tnegf) :: negf
     integer :: flag ! between 0:2
-    
+
     negf%ReadOldT_SGFs = flag
   end subroutine set_readOldTsgf
 
@@ -928,22 +928,22 @@ contains
     call kill_Tstruct(negf%str)
     if (allocated(negf%LDOS)) then
        call destroy_ldos(negf%ldos)
-    end if   
+    end if
     if (allocated(negf%en_grid)) then
        deallocate(negf%en_grid)
-    end if   
-    if (allocated(negf%tunn_mat)) then 
+    end if
+    if (allocated(negf%tunn_mat)) then
        call log_deallocate(negf%tunn_mat)
-    end if   
-    if (allocated(negf%curr_mat)) then 
+    end if
+    if (allocated(negf%curr_mat)) then
        call log_deallocate(negf%curr_mat)
-    end if   
+    end if
     if (allocated(negf%ldos_mat)) then
          call log_deallocate(negf%ldos_mat)
-    end if     
-    if (allocated(negf%currents)) then 
+    end if
+    if (allocated(negf%currents)) then
       call log_deallocate(negf%currents)
-    end if  
+    end if
     call destroy_DM(negf)
     call destroy_matrices(negf)
     !if (allocated(negf%cont)) deallocate(negf%cont)
@@ -1015,7 +1015,7 @@ contains
 
   end subroutine associate_current
 
-   
+
   !--------------------------------------------------------------------
   subroutine associate_lead_currents(negf, curr)
     type(TNegf), pointer, intent(in)  :: negf
@@ -1308,7 +1308,7 @@ contains
     call tunneling_int_def(negf)
     call ldos_int(negf)
     call destroy_matrices(negf)
-    
+
   end subroutine compute_ldos
 
   !-------------------------------------------------------------------------------
@@ -1339,7 +1339,7 @@ contains
     call tunneling_and_dos(negf)
 
     if (allocated(negf%tunn_mat)) then
-      call electron_current(negf)                   
+      call electron_current(negf)
     end if
     call destroy_matrices(negf)
 
@@ -1357,7 +1357,7 @@ contains
     call extract_cont(negf)
     call tunneling_int_def(negf)
     call meir_wingreen(negf)
- 
+
     if (allocated(negf%curr_mat)) then
       call electron_current_meir_wingreen(negf)
     end if
@@ -1401,7 +1401,7 @@ contains
     type(Tnegf), intent(in) :: negf
     integer, intent(in) :: esteps, npoints
     real(dp), dimension(:,:) :: ldos
-    
+
     integer :: i, j
 
     if (allocated(negf%ldos_mat) .and. &
@@ -1457,7 +1457,7 @@ contains
         write(ofKP,'(i6.6)') negf%kpoint
         write(idstr,'(i6.6)') id
 
-        open(newunit=iu,file=trim(negf%out_path)//'localDOS_'//ofKP//'_'//idstr//'.dat') 
+        open(newunit=iu,file=trim(negf%out_path)//'localDOS_'//ofKP//'_'//idstr//'.dat')
 
         do i = 1,Nstep
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,11 @@
-# List of active tets. Each test indicates a subdirectory. 
-set(test-directories 
-        c_int 
-        c_int_file 
-        f90int 
+# List of active tets. Each test indicates a subdirectory.
+set(test-directories
+        c_int
+        c_int_file
+        f90int
         f90int_file
         f90elph_deph
+        f90issue6
         )
 
 # Make BLAS and LAPACK available to be linked in the tests.
@@ -16,8 +17,8 @@ set(libs ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 # This is used to support out-of-source build, as the test
 # directory contain input files which we don't want to specify.
 function(transfer_test_data testname)
-    if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}") 
-        add_custom_target(${testname}-data-transfer)   
+    if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+        add_custom_target(${testname}-data-transfer)
     else()
         add_custom_target(
             ${testname}-data-transfer

--- a/tests/f90issue6/CMakeLists.txt
+++ b/tests/f90issue6/CMakeLists.txt
@@ -1,0 +1,1 @@
+setup_f90_test(f90issue6 f90issue6.F90)

--- a/tests/f90issue6/f90issue6.F90
+++ b/tests/f90issue6/f90issue6.F90
@@ -1,0 +1,41 @@
+!!--------------------------------------------------------------------------!
+!! libNEGF: a general library for Non-Equilibrium Green's functions.        !
+!! Copyright (C) 2012                                                       !
+!!                                                                          !
+!! This file is part of libNEGF: a library for                              !
+!! Non Equilibrium Green's Function calculation                             !
+!!                                                                          !
+!! Developers: Alessandro Pecchia, Gabriele Penazzi                         !
+!! Former Conctributors: Luca Latessa, Aldo Di Carlo                        !
+!!                                                                          !
+!! libNEGF is free software: you can redistribute it and/or modify          !
+!! it under the terms of the GNU Lesse General Public License as published  !
+!! by the Free Software Foundation, either version 3 of the License, or     !
+!! (at your option) any later version.                                      !
+!!                                                                          !
+!!  You should have received a copy of the GNU Lesser General Public        !
+!!  License along with libNEGF.  If not, see                                !
+!!  <http://www.gnu.org/licenses/>.                                         !
+!!--------------------------------------------------------------------------!
+
+!--------------------------------------------------------------------
+!>  Regression test for issue #6. Verify that we can initalize
+!!  an instance of libnegf and immediately destroy. It was not
+!!  previously possible due to problems in the inizalization of
+!!  contacts, and this test would crash.
+!--------------------------------------------------------------------
+program main
+
+  use libnegf
+  use lib_param
+
+  implicit none
+
+  Type(Tnegf) :: pnegf
+  Type(lnParams) :: params
+
+  call init_negf(pnegf)
+  call get_params(pnegf, params)
+  call destroy_negf(pnegf)
+
+end program main


### PR DESCRIPTION
- Fix for #6. 
  Eventually we want to remove `init_contacts`, I don't see the point in not doing the job directly inside `init_structure`. I did not do it in this PR because I don't wanna change the api. 
- Added a default contact names `Contact01`, `Contact02` etc. in initialization. 

Tested also with dftb+ 24debcc