### PR TITLE
Mpi c interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(BUILD_TESTING "Whether the tests should be built" FALSE)
 
 if(WITH_MPI)
   find_package(MPI REQUIRED)
-  set(MPIFX_INCLUDE_DIR "/usr/local/include/dftd3" CACHE PATH
+  set(MPIFX_INCLUDE_DIR "/usr/local/include/mpifx" CACHE PATH
     "Include directory of the MPIFX library (only if built with MPI)")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(BUILD_TESTING "Whether the tests should be built" FALSE)
 
 if(WITH_MPI)
   find_package(MPI REQUIRED)
-  set(MPIFX_INCLUDE_DIR "/opt/mpifx/include" CACHE PATH
+  set(MPIFX_INCLUDE_DIR "/usr/local/include/dftd3" CACHE PATH
     "Include directory of the MPIFX library (only if built with MPI)")
 endif()
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ the base directory:
 
 ```
 mkdir build
-cd build 
+cd build
 cmake ..
 make && make install
 ```
@@ -24,7 +24,15 @@ cmake .. -LAH
 If you want to build also the tests, enable the `BUILD_TESTING` option:
 
 ```
-cmake .. -DBUILD_TESTING=TRUE 
+cmake .. -DBUILD_TESTING=TRUE
 make && make test
 ```
 
+MPI support
+------------
+
+libNEGF can be compiled with parallel support. Note that in this case
+the library has to be linked to [mpifx](https://github.com/dftbplus/mpifx),
+which needs to be built separately.
+
+MPI support is enabled with the cmake flag `-DWITH_MPI=TRUE`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ set_target_properties(negf PROPERTIES Fortran_MODULE_DIRECTORY ${BUILD_MOD_DIR})
 
 if(WITH_MPI)
   target_include_directories(negf PRIVATE ${MPIFX_INCLUDE_DIR})
+  target_link_libraries(negf PRIVATE mpifx)
 endif()
 
 target_include_directories(negf PUBLIC

--- a/src/api/libnegf_api.f90
+++ b/src/api/libnegf_api.f90
@@ -245,7 +245,6 @@ subroutine negf_set_mpi_fcomm(handler, comm) bind(C)
 
   LIB = transfer(handler, LIB)
   call set_mpi_bare_comm(LIB%pNEGF, comm)
-  call negf_mpi_init(LIB%pNEGF%mpicomm)
 
 end subroutine negf_set_mpi_fcomm
 

--- a/src/api/libnegf_api.f90
+++ b/src/api/libnegf_api.f90
@@ -167,7 +167,7 @@ subroutine negf_init_structure(handler, ncont, contend, surfend, npl, plend, cbl
 end subroutine negf_init_structure
 
 !!* Pass contacts
-subroutine negf_init_contacts(handler, ncont) bind(c)
+subroutine negf_init_contacts(handler, ncont) bind(C)
   use iso_c_binding, only : c_int  ! if:mod:use
   use libnegfAPICommon  ! if:mod:use
   use libnegf           ! if:mod:use
@@ -214,7 +214,7 @@ end subroutine negf_get_params
 
 !!* Passing Hamiltonian from memory
 !!* @param  handler  Contains the handler for the new instance on return
-subroutine negf_set_h(handler, nrow, A, JA, IA)
+subroutine negf_set_h(handler, nrow, A, JA, IA) bind(C)
   use libnegfAPICommon  ! if:mod:use
   use libnegf           ! if:mod:use
   use ln_precision      ! if:mod:use
@@ -231,9 +231,27 @@ subroutine negf_set_h(handler, nrow, A, JA, IA)
   call set_H(LIB%pNEGF,nrow, A, JA, IA)
 end subroutine negf_set_h
 
+!!* Passing fortran style mpi communicator.
+!!* @param  handler The handler to this negf instance.
+subroutine negf_set_mpi_fcomm(handler, comm) bind(C)
+  use libnegfAPICommon  ! if:mod:use
+  use libnegf           ! if:mod:use
+  use ln_precision      ! if:mod:use
+  implicit none
+  integer :: handler(DAC_handlerSize)  ! if:var:in
+  integer, intent(in), value :: comm    ! if:var:in
+
+  type(NEGFpointers) :: LIB
+
+  LIB = transfer(handler, LIB)
+  call set_mpi_bare_comm(LIB%pNEGF, comm)
+  call negf_mpi_init(LIB%pNEGF%mpicomm)
+
+end subroutine negf_set_mpi_fcomm
+
 !!* Passing Overlap from memory
 !!* @param  handler  Contains the handler for the new instance on return
-subroutine negf_set_s(handler, nrow, A, JA, IA)
+subroutine negf_set_s(handler, nrow, A, JA, IA) bind(C)
   use libnegfAPICommon  ! if:mod:use
   use libnegf           ! if:mod:use
   use ln_precision      ! if:mod:use

--- a/src/libnegf.F90
+++ b/src/libnegf.F90
@@ -57,6 +57,7 @@ module libnegf
  public :: set_mpi_comm
  public :: negf_mpi_init !from mpi_globals
 #:endif
+ public :: set_mpi_bare_comm
 
  !Input and work flow procedures
  public :: lnParams
@@ -760,11 +761,40 @@ contains
   ! -------------------------------------------------------------------
 
 #:if defined("MPI")
+  !> Set a global mpifx communicator.
+  !!
+  !! @param [in] negf: libnegf container instance
+  !! @param [in] mpicomm: an mpifx communicator
   subroutine set_mpi_comm(negf, mpicomm)
     type(Tnegf) :: negf
     type(mpifx_comm) :: mpicomm
 
     negf%mpicomm = mpicomm
+  end subroutine
+
+  !> Set a global mpifx communicator from a bare communicator.
+  !!
+  !! @param [in] negf: libnegf container instance
+  !! @param [in] mpicomm: an mpi communicator
+  subroutine set_mpi_bare_comm(negf, mpicomm)
+    type(Tnegf), intent(inout) :: negf
+    integer, intent(in) :: mpicomm
+
+    type(mpifx_comm) :: mpifxcomm
+
+    call mpifxcomm%init(mpicomm)
+    negf%mpicomm = mpifxcomm
+
+  end subroutine
+#:else
+  !> Dummy method for the C-interface, when mpi implementation is missing.
+  !!
+  !! @param [in] negf: libnegf container instance
+  !! @param [in] mpicomm: unused.
+  subroutine set_mpi_bare_comm(negf, mpicomm)
+    type(Tnegf), intent(inout) :: negf
+    integer, intent(in) :: mpicomm
+
   end subroutine
 #:endif
   ! -------------------------------------------------------------------

--- a/src/libnegf.F90
+++ b/src/libnegf.F90
@@ -784,6 +784,7 @@ contains
 
     call mpifxcomm%init(mpicomm)
     negf%mpicomm = mpifxcomm
+    call negf_mpi_init(negf%mpicomm)
 
   end subroutine
 #:else

--- a/src/mpi_globals.F90
+++ b/src/mpi_globals.F90
@@ -1,9 +1,9 @@
 !!--------------------------------------------------------------------------!
 !! libNEGF: a general library for Non-Equilibrium Green's functions.        !
 !! Copyright (C) 2012                                                       !
-!!                                                                          ! 
+!!                                                                          !
 !! This file is part of libNEGF: a library for                              !
-!! Non Equilibrium Green's Function calculation                             ! 
+!! Non Equilibrium Green's Function calculation                             !
 !!                                                                          !
 !! Developers: Alessandro Pecchia, Gabriele Penazzi                         !
 !! Former Conctributors: Luca Latessa, Aldo Di Carlo                        !
@@ -15,47 +15,43 @@
 !!                                                                          !
 !!  You should have received a copy of the GNU Lesser General Public        !
 !!  License along with libNEGF.  If not, see                                !
-!!  <http://www.gnu.org/licenses/>.                                         !  
+!!  <http://www.gnu.org/licenses/>.                                         !
 !!--------------------------------------------------------------------------!
 
 
 module mpi_globals
 
+
 #:if defined("MPI")
-  
+
   use libmpifx_module
-  
+
+#:endif
+
   INTEGER, SAVE ::  mpi_comm
-  INTEGER, SAVE ::  numprocs
-  INTEGER, SAVE ::  id
-  LOGICAL, SAVE ::  id0
+  INTEGER, SAVE ::  numprocs = 1
+  INTEGER, SAVE ::  id = 0
+  LOGICAL, SAVE ::  id0 = .true.
+
+#:if defined("MPI")
 
   contains
-    
+
     subroutine negf_mpi_init(energyComm, ioMaster)
       type(mpifx_comm) :: energyComm
       logical, optional :: ioMaster
-      
+
       id =energyComm%rank
       numprocs = energyComm%size
-      
+
       if (present(ioMaster)) then
         id0 = ioMaster
       else
         id0 = (id == 0)
       end if
-      !print*, 'INIT MPI-NEGF ON',numprocs,'NODES' 
-      !print*, 'CPU',id,'READY'
-      !print*, 'PRINTING CPU:',id0
-      
+
     end subroutine negf_mpi_init
 
-#:else
-  
-  logical, parameter ::  id0 = .true.
-  integer, parameter :: id = 0, numprocs = 1
-         
 #:endif
-
 
 end module mpi_globals


### PR DESCRIPTION
Resolve #9 
We should open a separate ticket to clean up the existing api. I don't see why we need `set_mpi_comm(comm)` and then `negf_mpi_init(comm...)` in two different modules. We should have a single call.

Note: the way it is designed now a separate compilation of mpifx is needed. I chose to do this way because it's the easiest and does not mess up with DFTB+ compilation.  