### PR TITLE
Add different models for delta in phonon GF

### DIFF
--- a/src/api/lnParams.h
+++ b/src/api/lnParams.h
@@ -12,6 +12,8 @@ struct lnparams {
   int kpoint;
   double g_spin;
   double delta;
+  int deltaModel;
+  double wmax;
   double dos_delta;
   double eneconv;
   double wght;

--- a/src/integrations.F90
+++ b/src/integrations.F90
@@ -1724,12 +1724,14 @@ contains
        Ec = negf%en_grid(i)%Ec * negf%en_grid(i)%Ec
        negf%iE = negf%en_grid(i)%pt
 
-       ! delta*delta for reasons of units
-       delta = negf%delta * negf%delta
-       ! Mingo:
-       !delta = negf%delta*(1.0_dp-real(negf%en_grid(i)%Ec)/(negf%Emax+EPS12)) * Ec
-       ! Alex:
-       !delta = 2.0_dp * negf%delta * Ec
+       select case(negf%deltaModel)
+       case(DELTA_SQ)
+         delta = negf%delta * negf%delta
+       case(DELTA_W)
+         delta = negf%delta * real(negf%en_grid(i)%Ec)
+       case(DELTA_MINGO)
+         delta = negf%delta * (1.0_dp - real(negf%en_grid(i)%Ec)/(negf%wmax+1d-12)) * Ec
+       end select
 
        if (id0.and.negf%verbose.gt.VBT) call message_clock('Compute Contact SE ')
        call compute_contacts(Ec+j*delta,negf,ncyc,Tlc,Tcl,SelfEneR,GS)

--- a/src/lib_param.F90
+++ b/src/lib_param.F90
@@ -137,6 +137,9 @@ module lib_param
    real(dp) :: g_spin            ! spin degeneracy
    real(dp) :: delta             ! delta for G.F. 
    real(dp) :: dos_delta         ! additional delta to force more broadening in the DOS 
+   integer  :: deltaModel        ! Used for phonon G.F. ! delta**2, 2*delta*w, Mingo's
+   real(dp) :: wmax              ! Maximum frequency in Mingo's model
+                                 ! See 'Numerical Heat Transfer, Part B', 51:333, 2007
    real(dp) :: eneconv           ! Energy conversion factor
    integer  :: spin              ! spin component
    real(dp) :: wght              ! k-point weight 

--- a/src/lib_param.F90
+++ b/src/lib_param.F90
@@ -350,6 +350,8 @@ contains
 
      negf%delta = 1.d-4      ! delta for G.F. 
      negf%dos_delta = 1.d-4  ! delta for DOS 
+     negf%deltaModel = 1     ! deltaOmega model
+     negf%wmax = 0.009d0     ! about 2000 cm^-1 cutoff 
      negf%Emin = 0.d0        ! Tunneling or dos interval
      negf%Emax = 0.d0        ! 
      negf%Estep = 0.d0       ! Tunneling or dos E step

--- a/src/libnegf.F90
+++ b/src/libnegf.F90
@@ -45,7 +45,7 @@ module libnegf
 
  public :: log_deallocatep
  public :: r_CSR, z_CSR, r_DNS, z_DNS, create, destroy   !from matdef
- public :: HAR, eovh, pi, kb, units, set_drop             ! from ln_constants
+ public :: HAR, eovh, pi, kb, units, set_drop, DELTA_SQ, DELTA_W, DELTA_MINGO ! from ln_constants
  public :: convertCurrent, convertHeatCurrent, convertHeatConductance ! from ln_constants
  public :: Tnegf
  public :: set_bp_dephasing, set_elph_dephasing, set_elph_block_dephasing
@@ -134,6 +134,10 @@ module libnegf
    real(c_double) :: g_spin
    !> Imaginary delta
    real(c_double) :: delta
+   !> delta model for phonon GF
+   integer(c_int) :: deltaModel
+   !> Maximal energy in Mingo delta model
+   real(c_double) :: wmax
    !> Additional delta to force more broadening in the DOS
    real(c_double) :: dos_delta
    !> Energy conversion factor
@@ -551,6 +555,8 @@ contains
     params%readOldT_SGFs = negf%readOldT_SGFs
     params%g_spin = negf%g_spin
     params%delta = negf%delta
+    params%deltaModel = negf%deltaModel
+    params%wmax = negf%wmax
     params%dos_delta = negf%dos_delta
     nn = size(negf%cont)
     params%mu_n(1:nn) = negf%cont(1:nn)%mu_n
@@ -607,6 +613,8 @@ contains
     negf%readOldT_SGFs = params%readOldT_SGFs
     negf%g_spin = params%g_spin
     negf%delta = params%delta
+    negf%deltaModel = params%deltaModel
+    negf%wmax = params%wmax
     negf%dos_delta = params%dos_delta
     nn = size(negf%cont)
     negf%cont(1:nn)%mu_n        = params%mu_n(1:nn)

--- a/src/ln_constants.F90
+++ b/src/ln_constants.F90
@@ -67,6 +67,9 @@ module ln_constants
   ! electric conductance quantum:  
   real(dp), parameter    :: Go= 2*ee/hh                   ! A/V 
  
+  integer, parameter :: DELTA_SQ = 0
+  integer, parameter :: DELTA_W = 1
+  integer, parameter :: DELTA_MINGO = 2
 
   !!* Contains name of a units and its conversion factor
   type units


### PR DESCRIPTION
Added setting of different models for omega-dependent delta function in phonon GF.
It is done to set peace between different hardcoded implementations we've been using.