### PR TITLE
Mpifx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,9 @@ addons:
 
 install:
 - pip3 install fypp
-- git clone https://github.com/dftbplus/mpifx.git
-- cd mpifx && mkdir _build && cd _build
-- cmake -DCMAKE_INSTALL_PREFIX=/usr/  -DINSTALL_MOD_DIR=/usr/include/mpifx -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} ..
-- make && sudo make install
 
 script:
 - cd ${TRAVIS_BUILD_DIR} && mkdir _build && cd _build
-- cmake -DWITH_MPI=${WITH_MPI} -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DBUILD_TESTING=ON -DMPIFX_INCLUDE_DIR=/usr/include/mpifx ..
+- cmake -DWITH_MPI=${WITH_MPI} -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DBUILD_TESTING=ON ..
 - make -j 2
 - ctest -j 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ install:
 script:
 - cd ${TRAVIS_BUILD_DIR} && mkdir _build && cd _build
 - cmake -DWITH_MPI=${WITH_MPI} -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DBUILD_TESTING=ON ..
-- make -j 2
-- ctest -j 2
+- make
+- ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(libNEGF VERSION 0.3 LANGUAGES Fortran C)
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+include(externalMpifx)
 
 find_program(FYPP "fypp" PATHS "${CMAKE_SOURCE_DIR}/ext_fypp/bin")
 
@@ -26,12 +28,17 @@ option(INSTALL_INCLUDE_FILES "Whether module files and headers should be install
 
 option(BUILD_TESTING "Whether the tests should be built" FALSE)
 
+option(FORCE_MPIFX_INSTALL "Install mpifx from repository even if a version is found in the system" FALSE)
+
+# Requirements.
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
 if(WITH_MPI)
   find_package(MPI REQUIRED)
-  set(MPIFX_INCLUDE_DIR "/usr/local/include/mpifx" CACHE PATH
-    "Include directory of the MPIFX library (only if built with MPI)")
+  find_or_build_mpifx()
 endif()
 
+# Subdirectories.
 add_subdirectory(ext_sparskit)
 add_subdirectory(ext_system)
 add_subdirectory(src)

--- a/cmake/externalMpifx.cmake
+++ b/cmake/externalMpifx.cmake
@@ -17,13 +17,13 @@ function(find_or_build_mpifx)
 
     message("mpifx not found: adding a target to install from github")
     set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/external/mpifx)
+    set(MPIFX_INCLUDE_DIR ${EXTERNAL_INSTALL_LOCATION}/include PARENT_SCOPE)
+    set(MPIFX_LIBRARY "${EXTERNAL_INSTALL_LOCATION}/lib/libmpifx.a" PARENT_SCOPE)
     ExternalProject_Add(ext_mpifx
         GIT_REPOSITORY https://github.com/dftbplus/mpifx/
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
     )
 
-    set(MPIFX_INCLUDE_DIR ${EXTERNAL_INSTALL_LOCATION}/include PARENT_SCOPE)
-    set(MPIFX_LIBRARY "${EXTERNAL_INSTALL_LOCATION}/lib/libmpifx.a" PARENT_SCOPE)
   endif()
 
   include_directories(${MPIFX_INCLUDE_DIR})

--- a/cmake/externalMpifx.cmake
+++ b/cmake/externalMpifx.cmake
@@ -26,6 +26,6 @@ function(find_or_build_mpifx)
 
   endif()
 
-  include_directories(${MPIFX_INCLUDE_DIR})
+#   include_directories(${MPIFX_INCLUDE_DIR})
 
 endfunction()

--- a/cmake/externalMpifx.cmake
+++ b/cmake/externalMpifx.cmake
@@ -1,0 +1,31 @@
+include(ExternalProject)
+find_package(Git REQUIRED)
+
+function(find_or_build_mpifx)
+
+  find_library(
+      MPIFX_LIBRARY
+      NAMES mpifx
+      PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64
+      DOC "Find system mpifx")
+      # Figure out the include path and verify that at least the main module is
+      # there.
+  get_filename_component(MPIFX_DIRECTORY "${MPIFX_LIBRARY}" DIRECTORY)
+  set(MPIFX_INCLUDE_DIR "${MPIFX_DIRECTORY}/../include")
+
+  if (NOT MPIFX_LIBRARY OR NOT EXISTS "${MPIFX_INCLUDE_DIR}/libmpifx_module.mod" OR FORCE_MPIFX_INSTALL)
+
+    message("mpifx not found: adding a target to install from github")
+    set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/external/mpifx)
+    ExternalProject_Add(ext_mpifx
+        GIT_REPOSITORY https://github.com/dftbplus/mpifx/
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
+    )
+
+    set(MPIFX_INCLUDE_DIR ${EXTERNAL_INSTALL_LOCATION}/include PARENT_SCOPE)
+    set(MPIFX_LIBRARY "${EXTERNAL_INSTALL_LOCATION}/lib/libmpifx.a" PARENT_SCOPE)
+  endif()
+
+  include_directories(${MPIFX_INCLUDE_DIR})
+
+endfunction()

--- a/cmake/externalMpifx.cmake
+++ b/cmake/externalMpifx.cmake
@@ -22,6 +22,7 @@ function(find_or_build_mpifx)
     ExternalProject_Add(ext_mpifx
         GIT_REPOSITORY https://github.com/dftbplus/mpifx/
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
+        -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
     )
 
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,16 +65,16 @@ target_sources(negf PRIVATE $<TARGET_OBJECTS:syscalls_objlib>)
 target_include_directories(negf PUBLIC
   $<BUILD_INTERFACE:$<TARGET_PROPERTY:syscalls_objlib,INTERFACE_INCLUDE_DIRECTORIES>>)
 
-#target_link_libraries(negf PRIVATE sparskit)
-
 set(BUILD_MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 set_target_properties(negf PROPERTIES Fortran_MODULE_DIRECTORY ${BUILD_MOD_DIR})
 
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
 if(WITH_MPI)
   find_package(MPI REQUIRED)
   target_include_directories(negf PRIVATE ${MPIFX_INCLUDE_DIR})
-  target_link_libraries(negf PRIVATE mpifx)
+  target_link_libraries(negf PRIVATE ${MPIFX_LIBRARY} ${MPI_Fortran_LIBRARIES} ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 endif()
 
 target_include_directories(negf PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,12 +69,12 @@ set(BUILD_MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 set_target_properties(negf PROPERTIES Fortran_MODULE_DIRECTORY ${BUILD_MOD_DIR})
 
-find_package(BLAS REQUIRED)
-find_package(LAPACK REQUIRED)
 if(WITH_MPI)
   find_package(MPI REQUIRED)
   target_include_directories(negf PRIVATE ${MPIFX_INCLUDE_DIR})
   target_link_libraries(negf PRIVATE ${MPIFX_LIBRARY} ${MPI_Fortran_LIBRARIES} ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+else()
+  target_link_libraries(negf PRIVATE ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 endif()
 
 target_include_directories(negf PUBLIC

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,15 +10,6 @@ set(test-directories
         f90block_partition
         )
 
-# Make BLAS and LAPACK available to be linked in the tests.
-find_package(BLAS REQUIRED)
-find_package(LAPACK REQUIRED)
-if(WITH_MPI)
-  set(libs ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${MPI_Fortran_LIBRARIES})
-else()
-  set(libs ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
-endif()
-
 # Define a function wich copies over the content of the tests.
 # This is used to support out-of-source build, as the test
 # directory contain input files which we don't want to specify.
@@ -38,7 +29,7 @@ endfunction()
 function(setup_c_test testname source)
     add_executable(${testname} ${source})
     transfer_test_data(${testname})
-    target_link_libraries(${testname} negf ${libs})
+    target_link_libraries(${testname} negf)
     target_include_directories(${testname} PRIVATE ${CMAKE_BINARY_DIR}/src/api)
     add_test(${testname} ${testname})
 endfunction()
@@ -47,7 +38,7 @@ endfunction()
 function(setup_f90_test testname source)
     add_executable(${testname} ${source})
     transfer_test_data(${testname})
-    target_link_libraries(${testname} negf ${libs})
+    target_link_libraries(${testname} negf)
     target_include_directories(${testname} PRIVATE ${BUILD_MOD_DIR})
     add_test(${testname} ${testname})
 endfunction()


### PR DESCRIPTION
This PR improves the behavior of cmake for mpifx. A system library is searched. If not found, the package is pulled from the repository and compiled on-the-fly.
The CI build on travis always used this last mechanism. 

I also moved some liking from the test executables to the library itself, it should make it easier to link in other cmake projects. 