### PR TITLE
cmake small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
       - libscalapack-openmpi-dev
 
 install:
-- pip3 install fypp
 
 script:
 - cd ${TRAVIS_BUILD_DIR} && mkdir _build && cd _build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ project(libNEGF VERSION 0.3 LANGUAGES Fortran C)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 include(externalMpifx)
 
-find_program(FYPP "fypp" PATHS "${CMAKE_SOURCE_DIR}/ext_fypp/bin")
+set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/ext_fypp/;${CMAKE_PREFIX_PATH}")
+find_program(FYPP "fypp")
 
 set(FYPP "fypp" CACHE STRING "Fypp preprocessor")
 

--- a/cmake/externalMpifx.cmake
+++ b/cmake/externalMpifx.cmake
@@ -29,8 +29,12 @@ function(find_or_build_mpifx)
         -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
 	  -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
 	  -DCMAKE_Fortran_FLAGS=${CMAKE_Fortran_FLAGS}
-	  -DCMAKE_Fortran_FLAGS_RELEASE=${CMAKE_Fortran_FLAGS_RELEASE}
+    -DCMAKE_Fortran_FLAGS_RELEASE=${CMAKE_Fortran_FLAGS_RELEASE}
+    -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
     )
+
+    add_library(mpifx STATIC IMPORTED)
+    set_target_properties(mpifx PROPERTIES IMPORTED_LOCATION ${MPIFX_LIB})
 
   endif()
 


### PR DESCRIPTION
The last cmake PR was a bit rushed. I spotted 2 issues in the logic when mpifx is downloaded and compiled:
- fypp was not searched in the fallback libnegf location (ext_fypp)
- the library was not correctly added as dependency (libnegf wouldn't get linked to mpi libraries)

This PR fixes these, but there are at least 2 issues not addressed yes:
- if mpifx is downloaded and built on the fly, the compilation works serially but fails in parallel (make -j N).
- providing MPIFX_LIB and MPIFX_INCLUDE_DIR works, but ifwe do not provide explicitly those paths the library is not found in the system (which it should). 

I am planning to do another PR for these and check if the logic works fine with dftb+