### PR TITLE
Dephasing transmission

### DIFF
--- a/src/api/libnegf_api.f90
+++ b/src/api/libnegf_api.f90
@@ -546,6 +546,23 @@ subroutine negf_solve_landauer(handler) bind(C)
 end subroutine negf_solve_landauer
 
 !>
+!! Calculate transmission using a meir wingreen with dummy occupations.
+!! Only for 2 contacts and elastic interaction models.
+!! @param[in]  handler: handler Number for the LIBNEGF instance
+subroutine negf_calculate_dephasing_transmission(handler) bind(C)
+  use iso_c_binding, only : c_int  ! if:mod:use
+  use libnegfAPICommon  ! if:mod:use
+  use libnegf   ! if:mod:use
+  implicit none
+  integer(c_int), intent(in) :: handler(DAC_handlerSize)  ! if:var:in
+
+  type(NEGFpointers) :: LIB
+
+  LIB = transfer(handler, LIB)
+  call compute_dephasing_transmission(LIB%pNEGF)
+end subroutine negf_calculate_dephasing_transmission
+
+!>
 !! Calculate the density matrix for the dft problem
 !! @param[in]  handler: handler Number for the LIBNEGF instance
 subroutine negf_solve_density_dft(handler) bind(C)

--- a/src/api/libnegf_api.f90
+++ b/src/api/libnegf_api.f90
@@ -579,39 +579,6 @@ subroutine negf_solve_density_dft(handler) bind(C)
 end subroutine negf_solve_density_dft
 
 
-!>
-!! Get current value for a specific couple of leads
-!!  @param[in] handler: handler Number for the LIBNEGF instance
-!! @param [in] lead_pair: specifies which leads are considered
-!!             for retrieving current (as ordered in ni, nf)
-!!  @param[in] unitsOfH: units modifer for energy (write"unknown"
-!!                   for default)
-!!  @param[in] unitsOfJ: units modifier for current (write"unknown"
-!!                  for default)
-!!  @param[out] current: current value
-subroutine negf_get_current(handler, leadPair, unitsOfH, unitsOfJ, current)
-  use libnegfAPICommon  ! if:mod:use
-  use libnegf   ! if:mod:use
-  use ln_constants ! if:mod:use
-  use globals  ! if:mod:use
-  implicit none
-  integer :: handler(DAC_handlerSize)  ! if:var:in
-  integer :: leadPair      !if:var:in
-  real(dp) :: current       !if:var:inout
-  character(SST) :: unitsOfH !if:var:in
-  character(SST) :: unitsOfJ !if:var:in
-
-  type(NEGFpointers) :: LIB
-  type(units) :: unitsH, unitsJ
-
-  unitsH%name=trim(unitsOfH)
-  unitsJ%name=trim(unitsOfJ)
-  LIB = transfer(handler, LIB)
-  current = LIB%pNEGF%currents(leadPair) ! just take first value (2 contacts)
-  ! units conversion.
-  current = current * convertCurrent(unitsH, unitsJ)
-end subroutine negf_get_current
-
 !> Copy the energy axis on all processors (for output, plot, debug)
 !! Uses a fixed size array interface
 !! @param [in] handler:  handler Number for the LIBNEGF instance
@@ -863,44 +830,6 @@ subroutine negf_write_tunneling_and_dos(handler) bind(C)
 
 end subroutine negf_write_tunneling_and_dos
 
-
-!!* Sets iteration in self-consistent loops
-!!* @param handler Number for the LIBNEGF instance to destroy.
-!! SAME, IS IT REALLY NEEDED??
-subroutine negf_set_output(handler, out_path)
-  use libnegfAPICommon    ! if:mod:use
-  use globals             ! if:mod:use
-  use libnegf             ! if:mod:use
-  implicit none
-  integer :: handler(DAC_handlerSize)  ! if:var:in
-  character(LST) :: out_path(1)    ! if:var:in
-
-  type(NEGFpointers) :: LIB
-
-  LIB = transfer(handler, LIB)
-
-  LIB%pNEGF%out_path = trim( out_path(1) ) // '/'
-
-end subroutine negf_set_output
-
-
-!!* Sets iteration in self-consistent loops
-!!* @param handler Number for the LIBNEGF instance to destroy.
-subroutine negf_set_scratch(handler, scratch_path)
-  use libnegfAPICommon    ! if:mod:use
-  use globals             ! if:mod:use
-  use libnegf             ! if:mod:use
-  implicit none
-  integer :: handler(DAC_handlerSize)  ! if:var:in
-  character(LST) :: scratch_path(1)    ! if:var:in
-
-  type(NEGFpointers) :: LIB
-
-  LIB = transfer(handler, LIB)
-
-  LIB%pNEGF%scratch_path = trim( scratch_path(1) ) // '/'
-
-end subroutine negf_set_scratch
 
 !!* Instructs whether the device-contact part of the Density-Mat
 !!* needs to be computed (Relevant for charges in non-orthogonal bases)

--- a/src/integrations.F90
+++ b/src/integrations.F90
@@ -1636,9 +1636,7 @@ contains
 
     negf%currents=0.d0
     do ii=1,size_ni
-       mu1=negf%cont(negf%ni(ii))%mu
-       mu2=negf%cont(negf%nf(ii))%mu
-       negf%currents(ii)= integrate_el_meir_wingreen(negf%curr_mat(:,ii), mu1, mu2, &
+       negf%currents(ii)= integrate_el_meir_wingreen(negf%curr_mat(:,ii), &
                           & negf%Emin, negf%Emax, negf%Estep, negf%g_spin)
     enddo
 
@@ -1871,12 +1869,12 @@ contains
   ! Function to integrate the current density I(E) !!! and get the current
   ! for meir_wingreen
   !************************************************************************
-  function integrate_el_meir_wingreen(TUN_TOT,mu1,mu2,emin,emax,estep,spin_g)
+  function integrate_el_meir_wingreen(TUN_TOT,emin,emax,estep,spin_g)
 
     implicit none
 
     real(dp) :: integrate_el_meir_wingreen
-    real(dp), intent(in) :: mu1,mu2,emin,emax,estep
+    real(dp), intent(in) :: emin,emax,estep
     real(dp), dimension(:), intent(in) :: TUN_TOT
     real(dp), intent(in) :: spin_g
 

--- a/src/integrations.F90
+++ b/src/integrations.F90
@@ -1358,15 +1358,21 @@ contains
   !  leads and stored on negf%tunn_mat. The leads are specified in negf%ni
   !  We don't use the collector negf%nf because we need to specify only the
   !  lead for integration
+  !
+  ! The Fermi distribution for the contacts can be specified as optional input.
+  ! In this case the chemical potential and temperature are ignored and the
+  ! values must be constant in energy. This can be used for example to
+  ! calculate the effective transmission by forcing the value to be 0 or 1.
   !---------------------------------------------------------------------------
-  subroutine meir_wingreen(negf)
+  subroutine meir_wingreen(negf, fixed_occupations)
     type(Tnegf) :: negf
 
     integer :: scba_iter, i1
     real(dp) :: ncyc
     Type(z_DNS), Dimension(MAXNCONT) :: SelfEneR, Tlc, Tcl, GS
     Real(dp), Dimension(:), allocatable :: curr_mat
-    real(dp), DIMENSION(:), allocatable :: frm
+    real(dp), dimension(:), allocatable, optional :: fixed_occupations
+    real(dp), dimension(:), allocatable :: frm
     integer :: size_ni, ii, Nstep, outer, ncont, npl, j1, icont, jj
     complex(dp) :: Ec
     real(dp) :: scba_error
@@ -1383,7 +1389,10 @@ contains
       call log_allocate(negf%curr_mat,Nstep,size_ni)
     end if
     negf%curr_mat = 0.0_dp
-    call log_allocate(frm,ncont)
+    call log_allocate(frm, ncont)
+    if (present(fixed_occupations)) then
+      frm = fixed_occupations
+    end if
 
     call create_SGF_SE(negf)
     call read_SGF_SE(negf)
@@ -1399,9 +1408,11 @@ contains
       negf%iE = negf%en_grid(ii)%pt
       negf%trans%el%IndexEnergy=ii  !DAR
 
-      do j1 = 1,ncont
-         frm(j1)=fermi(real(Ec), negf%cont(j1)%mu, negf%cont(j1)%kbT_t)
-      enddo
+      if (.not. present(fixed_occupations)) then
+        do j1 = 1,ncont
+          frm(j1)=fermi(real(Ec), negf%cont(j1)%mu, negf%cont(j1)%kbT_t)
+        enddo
+      endif
 
       if(negf%tCalcSelfEnergies) then
          if (id0.and.negf%verbose.gt.VBT) call message_clock('Compute Contact SE ')

--- a/src/libnegf.F90
+++ b/src/libnegf.F90
@@ -1457,27 +1457,20 @@ contains
     end if
 
     if (negf%elph%model .gt. 3) then
-      error stop "Effective transmission is only supported for 2 electrodes"
+      error stop "Effective transmission is only supported for dephasing models"
     end if
 
     call extract_cont(negf)
     call tunneling_int_def(negf)
-    ! Dirty trick. Set the contact population to 1 or 0 on the reference (depending
-    ! whether maximum or minimum chemical potential was chosen), and opposite on the
-    ! other contact.
+    ! Dirty trick. Set the contact population to 1 on the final contact and
+    ! 1 on the initial one.
     allocate(occupations(2))
-    if (negf%min_or_max .eq. 0) then
-      occupations(negf%refcont) = 0
-      occupations(mod(negf%refcont, 2) + 1) = 1
-    else
-      occupations(negf%refcont) = 1
-      occupations(mod(negf%refcont, 2) + 1) = 0
-    end if
+    occupations(negf%ni(1)) = 0.d0
+    occupations(negf%nf(1)) = 1.d0
 
     call meir_wingreen(negf, fixed_occupations=occupations)
     ! Assign the current matrix values to the transmission.
-    ! TODO: check why I need to flip sign here. How is the sign convention for the current?
-    negf%tunn_mat = - negf%curr_mat
+    negf%tunn_mat = negf%curr_mat
 
     call electron_current(negf)
     call destroy_matrices(negf)

--- a/src/libnegf.F90
+++ b/src/libnegf.F90
@@ -471,29 +471,29 @@ contains
 
      ! Make sure we called init_contacts in a consistent way.
      if (size(negf%cont) .ne. ncont) then
-       write(*, *) 'size(negf%cont)=',size(negf%cont),'<->  ncont=',ncont     
+       write(*, *) 'size(negf%cont)=',size(negf%cont),'<->  ncont=',ncont
        stop "Error in set_structure: ncont not compatible with previous initialization."
      end if
      ! More sanity checks.
      if (size(surfstart) .ne. ncont) then
-       write(*, *) 'size(surfstart)=',size(surfstart),'<->  ncont=',ncont     
+       write(*, *) 'size(surfstart)=',size(surfstart),'<->  ncont=',ncont
        stop "Error in set_structure: surfend and ncont mismatch"
      end if
      if (size(surfend) .ne. ncont) then
-       write(*, *) 'size(surfend)=',size(surfend),'<->  ncont=',ncont     
+       write(*, *) 'size(surfend)=',size(surfend),'<->  ncont=',ncont
        stop "Error in set_structure: surfend and ncont mismatch"
      end if
      if (size(contend) .ne. ncont) then
-       write(*, *) 'size(contend)=',size(contend),'<->  ncont=',ncont     
+       write(*, *) 'size(contend)=',size(contend),'<->  ncont=',ncont
        stop "Error in set_structure: contend and ncont mismatch"
      end if
      if (npl .ne. 0 .and. size(plend) .ne. npl) then
-       write(*, *) 'size(plend)=',size(plend),'<->  npl=',npl    
+       write(*, *) 'size(plend)=',size(plend),'<->  npl=',npl
        stop "Error in set_structure: plend and npl mismatch"
      end if
 
      if (npl .eq. 0) then
-       ! supposedly performs an internal block partitioning but it is not reliable.     
+       ! supposedly performs an internal block partitioning but it is not reliable.
        call log_allocate(plend_tmp, MAXNUMPLs)
        call block_partition(negf%H, surfend(1), contend, surfend, ncont, npl_tmp, plend_tmp)
        call log_allocate(cblk_tmp, MAXNUMPLs)
@@ -796,7 +796,7 @@ contains
       if (size(negf%tun_proj%indexes) /= size(idx)) then
          write(*,*) 'ERROR in set_tun_indexes size mismatch'
          return
-      end if   
+      end if
     end if
     negf%tun_proj%indexes = idx
 
@@ -890,10 +890,10 @@ contains
   !> Initialize and set parameters from input file negf.in
   subroutine read_negf_in(negf)
     type(Tnegf) :: negf
-    
+
     integer :: ncont, nbl, ii, jj, ist, iend
     integer, dimension(:), allocatable :: PL_end, cont_end, surf_end
-    integer, dimension(:), allocatable :: surf_start, cblk 
+    integer, dimension(:), allocatable :: surf_start, cblk
     character(32) :: tmp
     character(LST) :: file_re_H, file_im_H, file_re_S, file_im_S
 
@@ -921,7 +921,7 @@ contains
     call log_allocate(surf_start,ncont)
     call log_allocate(surf_end,ncont)
     call log_allocate(cont_end,ncont)
-    
+
     read(101,*) tmp, nbl
     if (nbl .gt. 0) then
        call log_allocate(PL_end,nbl)
@@ -930,7 +930,7 @@ contains
     read(101,*) tmp, surf_start(1:ncont)
     read(101,*) tmp, surf_end(1:ncont)
     read(101,*) tmp, cont_end(1:ncont)
-  
+
     call find_cblocks(negf%H, ncont, nbl, PL_end, surf_start, cont_end, cblk)
     call init_structure(negf, ncont, surf_start, surf_end, cont_end, nbl, PL_end, cblk)
 
@@ -1440,12 +1440,58 @@ contains
   end subroutine compute_landauer
 
   !-------------------------------------------------------------------------------
+  !> Calculate current and tunnelling for elastic el-ph dephasing models.
+  !> Since the "real" landauer-like formula is not implemented yet, we use
+  !> a dirty trick only valid for 2 contacts.
+  !! @param negf input/output container
+  subroutine compute_effective_transmission(negf)
+
+    type(Tnegf) :: negf
+    real(dp), allocatable, dimension(:) :: mu
+
+    if (negf%str%num_conts .ne. 2) then
+      error stop "Effective transmission is only supported for 2 electrodes"
+    end if
+
+    call extract_cont(negf)
+    call tunneling_int_def(negf)
+    ! Dirty trick. Set the chemical potential such that the energy resolved current
+    ! is indeed a transmission.
+    mu = (/ negf%cont(1)%mu, negf%cont(2)%mu /)
+    if (mu(1) .le. mu(2)) then
+      negf%cont(1)%mu = negf%Emin - 20 * negf%cont(1)%kbT_t
+      negf%cont(2)%mu = negf%Emax + 20 * negf%cont(2)%kbT_t
+    else
+      negf%cont(2)%mu = negf%Emin - 20 * negf%cont(2)%kbT_t
+      negf%cont(1)%mu = negf%Emax + 20 * negf%cont(1)%kbT_t
+    end if
+
+    call meir_wingreen(negf)
+    ! Assign the current matrix values to the transmission.
+    ! TODO: check why I need to flip sign here. How is the sign convention for the current?
+    negf%tunn_mat = - negf%curr_mat
+
+    ! Restore the correct chemical potential for integration.
+    negf%cont(1)%mu = mu(1)
+    negf%cont(2)%mu = mu(2)
+
+    call electron_current(negf)
+    call destroy_matrices(negf)
+
+  end subroutine compute_effective_transmission
+
+  !-------------------------------------------------------------------------------
   !> Calculate current, tunneling and, if specified, density of states using
   !! Landauer formula. DOS is calculated during the T(E) loop
   !! @param negf input/output container
   subroutine compute_meir_wingreen(negf)
 
     type(Tnegf) :: negf
+
+    if (negf%str%num_conts .eq. 2) then
+      call compute_effective_transmission(negf)
+      return
+    end if
 
     call extract_cont(negf)
     call tunneling_int_def(negf)


### PR DESCRIPTION
I've been looking at getting the effective transmission for dephasing models. A landauer-like implementation for the multi-terminal case as derived in the paper (eq. 31) requires to work on the single contributions Gr Gam_i Ga from each contact, it would be nice to have but definitely some work. I made this PR to support the case with 2 contacts with a simple trick on the occupation, we could think of having this for inclusion in DFTB+ and then generalize. 

I also removed some subroutines from libnegf_api as they are not C compatible (they won't allow bind(C), not sure how/if they'd be used anywhere)