### PR TITLE
Refactoring block matrix 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,8 @@ set(sources-fpp
   interactions.F90
   elphdd.F90
   elphdb.F90
-  elphds.F90)
+  elphds.F90
+  ln_blockmat.F90)
 
 if(WITH_INELASTIC)
   list(APPEND sources-fpp transform.F90)

--- a/src/iterative.F90
+++ b/src/iterative.F90
@@ -146,7 +146,6 @@ CONTAINS
     call destroy_blockmat(ESH)
 
     call destroy_gsm(gsmr)
-    call deallocate_gsm(gsmr)
 
 
     ! SAVE ON FILES/MEMORY (for elph).........................
@@ -291,9 +290,7 @@ CONTAINS
     !Otherwise they are still needed to calculate columns ont-the-fly.
     if (.not.allocated(negf%inter)) then
       call destroy_gsm(gsmr)
-      call deallocate_gsm(gsmr)
       call destroy_gsm(gsml)
-      call deallocate_gsm(gsml)
     end if
 
     !Computing device G_n
@@ -307,9 +304,7 @@ CONTAINS
     if (allocated(negf%inter)) then
       call calculate_Gn_tridiag_elph_contributions(negf,ESH%blocks,iter,Gn%blocks,Gr_columns)
       call destroy_gsm(gsmr)
-      call deallocate_gsm(gsmr)
       call destroy_gsm(gsml)
-      call deallocate_gsm(gsml)
     end if
 
     call destroy_blockmat(ESH)
@@ -435,9 +430,7 @@ CONTAINS
     ! The gsmr, gsml are used to calculate columns on-the-fly in calculate_Gn_tridiag_elph_contributions, we
     ! can destroy them here.
     call destroy_gsm(gsmr)
-    call deallocate_gsm(gsmr)
     call destroy_gsm(gsml)
-    call deallocate_gsm(gsml)
 
     do i=1,size(negf%ni)
       lead = negf%ni(i)
@@ -605,7 +598,7 @@ CONTAINS
 
   !**********************************************************************
   subroutine destroy_gsm(gsm)
-    type(z_DNS), dimension(:) :: gsm
+    type(z_DNS), dimension(:), allocatable :: gsm
     integer :: i, i1, nbl
 
     nbl=size(gsm,1)
@@ -613,6 +606,7 @@ CONTAINS
     do i=1,nbl
       if (allocated(gsm(i)%val)) call destroy(gsm(i))
     end do
+    deallocate(gsm)
 
   end subroutine destroy_gsm
 
@@ -3235,7 +3229,6 @@ CONTAINS
 
     !Deallocate energy-dependent matrices
     call destroy_gsm(gsmr)
-    call deallocate_gsm(gsmr)
 
     call destroy_blockmat(ESH)
 
@@ -3535,7 +3528,6 @@ CONTAINS
 
     !Deallocate energy-dependent matrices
     call destroy_gsm(gsmr)
-    call deallocate_gsm(gsmr)
 
     !Distruzione dei blocchi fuori-diagonale
     do i=2,nbl

--- a/src/iterative.F90
+++ b/src/iterative.F90
@@ -136,7 +136,7 @@ CONTAINS
     if (allocated(negf%inter)) call negf%inter%add_sigma_r(ESH%blocks)
 
     call allocate_gsm(gsmr,nbl)
-    call calculate_gsmr_blocks(ESH%blocks,nbl,2)
+    call calculate_gsmr_blocks(ESH,nbl,2)
 
     call create_blockmat(Gr, negf%str%mat_PL_start)
 
@@ -259,8 +259,8 @@ CONTAINS
       lbl = maxval(cblk(1:ncont),mask(1:ncont))
     endif
 
-    call calculate_gsmr_blocks(ESH%blocks,nbl,rbl+1)
-    call calculate_gsml_blocks(ESH%blocks,1,lbl-1)
+    call calculate_gsmr_blocks(ESH,nbl,rbl+1)
+    call calculate_gsml_blocks(ESH,1,lbl-1)
 
     call create_blockmat(Gr, negf%str%mat_PL_start)
 
@@ -390,10 +390,10 @@ CONTAINS
     call allocate_gsm(gsmr,nbl)
     call allocate_gsm(gsml,nbl)
 
-    call calculate_gsmr_blocks(ESH%blocks,nbl,2)
+    call calculate_gsmr_blocks(ESH,nbl,2)
 
     if ( ncont.gt.1 ) then
-      call calculate_gsml_blocks(ESH%blocks,1,nbl-2)
+      call calculate_gsml_blocks(ESH,1,nbl-2)
     endif
 
     call create_blockmat(Gr, negf%str%mat_PL_start)
@@ -811,7 +811,7 @@ CONTAINS
     implicit none
 
     !In/Out
-    type(z_DNS), dimension(:,:), intent(in) :: ESH
+    type(TSquareBlockZDns), intent(in) :: ESH
     integer, intent(in) :: sbl,ebl                 ! start block, end block
 
     !Work
@@ -822,26 +822,26 @@ CONTAINS
 
     if (sbl.lt.ebl) return
 
-    nbl = size(ESH,1)
+    nbl = ESH%nblocks
 
     if (nbl.eq.1) return
 
-    nrow=ESH(sbl,sbl)%nrow
+    nrow=ESH%blocks(sbl,sbl)%nrow
 
     call create(gsmr(sbl),nrow,nrow)
 
-    call compGreen(gsmr(sbl),ESH(sbl,sbl),nrow)
+    call compGreen(gsmr(sbl),ESH%blocks(sbl,sbl),nrow)
 
 
     do i=sbl-1,ebl,-1
 
-      call prealloc_mult(ESH(i,i+1),gsmr(i+1),(-1.0_dp, 0.0_dp),work1)
+      call prealloc_mult(ESH%blocks(i,i+1),gsmr(i+1),(-1.0_dp, 0.0_dp),work1)
 
-      call prealloc_mult(work1,ESH(i+1,i),work2)
+      call prealloc_mult(work1,ESH%blocks(i+1,i),work2)
 
       call destroy(work1)
 
-      call prealloc_sum(ESH(i,i),work2,work1)
+      call prealloc_sum(ESH%blocks(i,i),work2,work1)
 
       call destroy(work2)
 
@@ -883,7 +883,7 @@ CONTAINS
     implicit none
 
     !In/Out
-    type(z_DNS), dimension(:,:), intent(in) :: ESH
+    type(TSquareBlockZDns), intent(in) :: ESH
     integer, intent(in) :: sbl,ebl                       ! start block, end block
 
     !Work
@@ -894,28 +894,28 @@ CONTAINS
 
     if (sbl.gt.ebl) return
 
-    nbl = size(ESH,1)
+    nbl = ESH%nblocks
 
     if (nbl.eq.1) return
 
-    nrow=ESH(sbl,sbl)%nrow
+    nrow=ESH%blocks(sbl,sbl)%nrow
 
     call create(gsml(sbl),nrow,nrow)
 
-    call compGreen(gsml(sbl),ESH(sbl,sbl),nrow)
+    call compGreen(gsml(sbl),ESH%blocks(sbl,sbl),nrow)
 
 
     do i=sbl+1,ebl
 
-      nrow=ESH(i,i)%nrow
+      nrow=ESH%blocks(i,i)%nrow
 
-      call prealloc_mult(ESH(i,i-1),gsml(i-1),(-1.0_dp, 0.0_dp),work1)
+      call prealloc_mult(ESH%blocks(i,i-1),gsml(i-1),(-1.0_dp, 0.0_dp),work1)
 
-      call prealloc_mult(work1,ESH(i-1,i),work2)
+      call prealloc_mult(work1,ESH%blocks(i-1,i),work2)
 
       call destroy(work1)
 
-      call prealloc_sum(ESH(i,i),work2,work1)
+      call prealloc_sum(ESH%blocks(i,i),work2,work1)
 
       call destroy(work2)
 
@@ -3084,7 +3084,7 @@ CONTAINS
     call allocate_gsm(gsmr,nbl)
 
     !Iterative calculation up with gsmr
-    call calculate_gsmr_blocks(ESH%blocks,nbl,2)
+    call calculate_gsmr_blocks(ESH,nbl,2)
 
     do icpl = 1, size(ni)
 
@@ -3413,7 +3413,7 @@ CONTAINS
 
     call allocate_gsm(gsmr,nbl)
 
-    call calculate_gsmr_blocks(ESH%blocks,nbl,2)
+    call calculate_gsmr_blocks(ESH,nbl,2)
 
     call create_blockmat(Gr, str%mat_PL_start)
 

--- a/src/iterative.F90
+++ b/src/iterative.F90
@@ -132,7 +132,7 @@ CONTAINS
     ! Take CSR H,S and build ES-H in dense blocks
     call prealloc_sum(negf%H,negf%S,(-1.0_dp, 0.0_dp),E,ESH_tot)
 
-    call csr_to_tridiagonal_blockmat(ESH_tot, negf%str%mat_PL_start, ESH)
+    call create_tridiagonal_blockmat(ESH, ESH_tot, negf%str%mat_PL_start)
     call destroy(ESH_tot)
 
     do i=1, ncont
@@ -247,7 +247,7 @@ CONTAINS
     ! Take CSR H,S and build ES-H in dense blocks
     call prealloc_sum(negf%H,negf%S,(-1.0_dp, 0.0_dp),Ec,ESH_tot)
 
-    call csr_to_tridiagonal_blockmat(ESH_tot, negf%str%mat_PL_start, ESH)
+    call create_tridiagonal_blockmat(ESH, ESH_tot, negf%str%mat_PL_start)
     call destroy(ESH_tot)
 
     do i=1, ncont

--- a/src/ln_blockmat.F90
+++ b/src/ln_blockmat.F90
@@ -1,0 +1,113 @@
+!!--------------------------------------------------------------------------!
+!! libNEGF: a general library for Non-Equilibrium Green's functions.        !
+!! Copyright (C) 2012                                                       !
+!!                                                                          !
+!! This file is part of libNEGF: a library for                              !
+!! Non Equilibrium Green's Function calculation                             !
+!!                                                                          !
+!! Developers: Alessandro Pecchia, Gabriele Penazzi                         !
+!! Former Conctributors: Luca Latessa, Aldo Di Carlo                        !
+!!                                                                          !
+!! libNEGF is free software: you can redistribute it and/or modify          !
+!! it under the terms of the GNU Lesse General Public License as published  !
+!! by the Free Software Foundation, either version 3 of the License, or     !
+!! (at your option) any later version.                                      !
+!!                                                                          !
+!!  You should have received a copy of the GNU Lesser General Public        !
+!!  License along with libNEGF.  If not, see                                !
+!!  <http://www.gnu.org/licenses/>.                                         !
+!!--------------------------------------------------------------------------!
+
+
+module ln_blockmat
+  use ln_precision
+  use ln_allocation
+  use mat_def, only : z_DNS, create, destroy
+  implicit none
+  private
+
+
+public :: TSquareBlockZDns
+public :: create_blockmat, destroy_blockmat, init_tridiagonal_blockmat
+
+!> A square block matrix with blocks of type z_DNS.
+type TSquareBlockZDns
+   type(z_DNS), dimension(:,:), allocatable :: blocks
+   integer :: nrow = 0
+end type TSquareBlockZDns
+
+interface create_blockmat
+   module procedure create_blockmat_zdns
+end interface
+
+interface destroy_blockmat
+   module procedure destroy_blockmat_zdns
+end interface
+
+interface init_tridiagonal_blockmat
+   module procedure init_tridiagonal_blockmat_zdns
+end interface
+
+contains
+
+!> Create a block matrix. The individual blocks are not allocated here.
+subroutine create_blockmat_zdns(matrix, nrow)
+   !> The matrix to be created.
+   type(TSquareBlockZDns), intent(out) :: matrix
+   !> The number of block rows.
+   integer, intent(in) :: nrow
+
+   allocate(matrix%blocks(nrow, nrow))
+   matrix%nrow = nrow
+
+end subroutine create_blockmat_zdns
+
+!> Destroy a block matrix.
+subroutine destroy_blockmat_zdns(matrix)
+   !> The matrix to be created.
+   type(TSquareBlockZDns), intent(out) :: matrix
+
+   if (allocated(matrix%blocks)) then
+      deallocate(matrix%blocks)
+   endif
+   matrix%nrow = 0
+
+end subroutine destroy_blockmat_zdns
+
+!> Initialize a tridiagonal block matrix with the same blocks
+!> as a sample one, but filled with zeros.
+subroutine init_tridiagonal_blockmat_zdns(sample_matrix, matrix)
+   !> The matrix which provides the tridiagonal blocks size
+   type(TSquareBlockZDns), intent(in) :: sample_matrix
+   !> The matrix to initialize
+   type(TSquareBlockZDns), intent(out) :: matrix
+
+   integer :: nbl, j
+
+   call destroy_blockmat(matrix)
+   call create_blockmat(matrix, sample_matrix%nrow)
+
+   nbl = sample_matrix%nrow
+
+   call create(matrix%blocks(1,1), sample_matrix%blocks(1,1)%nrow, sample_matrix%blocks(1,1)%ncol)
+   matrix%blocks(1,1)%val=(0.0_dp,0.0_dp)
+   do j=2,nbl-1
+      call create(matrix%blocks(j-1,j),sample_matrix%blocks(j-1,j)%nrow,sample_matrix%blocks(j-1,j)%ncol)
+      matrix%blocks(j-1,j)%val=(0.0_dp,0.0_dp)
+      call create(matrix%blocks(j,j),sample_matrix%blocks(j,j)%nrow,sample_matrix%blocks(j,j)%ncol)
+      matrix%blocks(j,j)%val=(0.0_dp,0.0_dp)
+      call create(matrix%blocks(j,j-1),sample_matrix%blocks(j,j-1)%nrow,sample_matrix%blocks(j,j-1)%ncol)
+      matrix%blocks(j,j-1)%val=(0.0_dp,0.0_dp)
+   end do
+   if (nbl.gt.1) then
+      call create(matrix%blocks(nbl,nbl),sample_matrix%blocks(nbl,nbl)%nrow,sample_matrix%blocks(nbl,nbl)%ncol)
+      matrix%blocks(nbl,nbl)%val=(0.0_dp,0.0_dp)
+      call create(matrix%blocks(nbl-1,nbl),sample_matrix%blocks(nbl-1,nbl)%nrow,sample_matrix%blocks(nbl-1,nbl)%ncol)
+      matrix%blocks(nbl-1,nbl)%val=(0.0_dp,0.0_dp)
+      call create(matrix%blocks(nbl,nbl-1),sample_matrix%blocks(nbl,nbl-1)%nrow,sample_matrix%blocks(nbl,nbl-1)%ncol)
+      matrix%blocks(nbl,nbl-1)%val=(0.0_dp,0.0_dp)
+   endif
+
+end subroutine init_tridiagonal_blockmat_zdns
+
+end module ln_blockmat

--- a/src/ln_blockmat.F90
+++ b/src/ln_blockmat.F90
@@ -21,12 +21,14 @@
 module ln_blockmat
   use ln_precision
   use ln_allocation
-  use mat_def, only: z_DNS, create, destroy
+  use mat_def, only: z_CSR, z_DNS, create, destroy
+  use sparsekit_drv, only: extract
   implicit none
   private
 
   public :: TSquareBlockZDns
-  public :: create_blockmat, destroy_blockmat, init_tridiagonal_blockmat
+  public :: create_blockmat, destroy_blockmat, init_tridiagonal_blockmat, &
+            csr_to_tridiagonal_blockmat, subtract_from_block
 
 !> A square block matrix with blocks of type z_DNS.
   type TSquareBlockZDns
@@ -46,6 +48,14 @@ module ln_blockmat
     module procedure init_tridiagonal_blockmat_zdns
   end interface
 
+  interface csr_to_tridiagonal_blockmat
+    module procedure zcsr_to_tridiagonal_blockmat_zdns
+  end interface
+
+  interface subtract_from_block
+    module procedure subtract_from_block_zdns
+  end interface
+
 contains
 
 !> Create a block matrix. The individual blocks are not allocated here.
@@ -54,6 +64,10 @@ contains
     type(TSquareBlockZDns), intent(out) :: matrix
     !> The number of block rows.
     integer, intent(in) :: nrow
+
+    if (allocated(matrix%blocks)) then
+      call destroy_blockmat(matrix)
+    end if
 
     allocate (matrix%blocks(nrow, nrow))
     matrix%nrow = nrow
@@ -67,7 +81,7 @@ contains
 
     if (allocated(matrix%blocks)) then
       deallocate (matrix%blocks)
-    endif
+    end if
     matrix%nrow = 0
 
   end subroutine destroy_blockmat_zdns
@@ -82,30 +96,78 @@ contains
 
     integer :: nbl, j
 
-    call destroy_blockmat(matrix)
     call create_blockmat(matrix, sample_matrix%nrow)
 
     nbl = sample_matrix%nrow
 
-    call create(matrix%blocks(1, 1), sample_matrix%blocks(1, 1)%nrow, sample_matrix%blocks(1, 1)%ncol)
-    matrix%blocks(1, 1)%val = (0.0_dp, 0.0_dp)
-    do j = 2, nbl - 1
-      call create(matrix%blocks(j - 1, j), sample_matrix%blocks(j - 1, j)%nrow, sample_matrix%blocks(j - 1, j)%ncol)
-      matrix%blocks(j - 1, j)%val = (0.0_dp, 0.0_dp)
-      call create(matrix%blocks(j, j), sample_matrix%blocks(j, j)%nrow, sample_matrix%blocks(j, j)%ncol)
-      matrix%blocks(j, j)%val = (0.0_dp, 0.0_dp)
-      call create(matrix%blocks(j, j - 1), sample_matrix%blocks(j, j - 1)%nrow, sample_matrix%blocks(j, j - 1)%ncol)
-      matrix%blocks(j, j - 1)%val = (0.0_dp, 0.0_dp)
-    end do
-    if (nbl .gt. 1) then
-      call create(matrix%blocks(nbl, nbl), sample_matrix%blocks(nbl, nbl)%nrow, sample_matrix%blocks(nbl, nbl)%ncol)
-      matrix%blocks(nbl, nbl)%val = (0.0_dp, 0.0_dp)
-      call create(matrix%blocks(nbl - 1, nbl), sample_matrix%blocks(nbl - 1, nbl)%nrow, sample_matrix%blocks(nbl - 1, nbl)%ncol)
-      matrix%blocks(nbl - 1, nbl)%val = (0.0_dp, 0.0_dp)
-      call create(matrix%blocks(nbl, nbl - 1), sample_matrix%blocks(nbl, nbl - 1)%nrow, sample_matrix%blocks(nbl, nbl - 1)%ncol)
-      matrix%blocks(nbl, nbl - 1)%val = (0.0_dp, 0.0_dp)
-    endif
+    associate (bl => sample_matrix%blocks)
+
+      call create(matrix%blocks(1, 1), bl(1, 1)%nrow, bl(1, 1)%ncol)
+      matrix%blocks(1, 1)%val = (0.0_dp, 0.0_dp)
+      do j = 2, nbl - 1
+        call create(matrix%blocks(j - 1, j), bl(j - 1, j)%nrow, bl(j - 1, j)%ncol)
+        matrix%blocks(j - 1, j)%val = (0.0_dp, 0.0_dp)
+        call create(matrix%blocks(j, j), bl(j, j)%nrow, bl(j, j)%ncol)
+        matrix%blocks(j, j)%val = (0.0_dp, 0.0_dp)
+        call create(matrix%blocks(j, j - 1), bl(j, j - 1)%nrow, bl(j, j - 1)%ncol)
+        matrix%blocks(j, j - 1)%val = (0.0_dp, 0.0_dp)
+      end do
+      if (nbl .gt. 1) then
+        call create(matrix%blocks(nbl, nbl), bl(nbl, nbl)%nrow, bl(nbl, nbl)%ncol)
+        matrix%blocks(nbl, nbl)%val = (0.0_dp, 0.0_dp)
+        call create(matrix%blocks(nbl - 1, nbl), bl(nbl - 1, nbl)%nrow, bl(nbl - 1, nbl)%ncol)
+        matrix%blocks(nbl - 1, nbl)%val = (0.0_dp, 0.0_dp)
+        call create(matrix%blocks(nbl, nbl - 1), bl(nbl, nbl - 1)%nrow, bl(nbl, nbl - 1)%ncol)
+        matrix%blocks(nbl, nbl - 1)%val = (0.0_dp, 0.0_dp)
+      end if
+
+    end associate
 
   end subroutine init_tridiagonal_blockmat_zdns
+
+!> Convert a CSR matrix to a tridiagonal block square. Entries out of the
+!> tridiagonal blocks are ignored. The block matrix is constructed internally.
+  subroutine zcsr_to_tridiagonal_blockmat_zdns(csr_matrix, indices, block_matrix)
+    !> The CSR matrix to copy values from.
+    type(z_CSR), intent(in) :: csr_matrix
+    !> The starting index of each box. The last index must be the final row + 1.
+    integer, dimension(:), allocatable, intent(in) :: indices
+    !> The output block matrix.
+    type(TSquareBlockZDns), intent(out) :: block_matrix
+
+    integer :: i, nbl
+
+    call create_blockmat(block_matrix, csr_matrix%nrow)
+
+    nbl = size(indices) - 1
+
+    do i = 1, nbl
+      call extract(csr_matrix, indices(i), indices(i + 1) - 1, indices(i), &
+          & indices(i + 1) - 1, block_matrix%blocks(i, i))
+    end do
+
+    do i = 2, nbl
+      call extract(csr_matrix, indices(i - 1), indices(i) - 1, indices(i), &
+          & indices(i + 1) - 1, block_matrix%blocks(i - 1, i))
+      call extract(csr_matrix, indices(i), indices(i + 1) - 1, indices(i - 1), &
+          & indices(i) - 1, block_matrix%blocks(i, i - 1))
+    end do
+
+  end subroutine zcsr_to_tridiagonal_blockmat_zdns
+
+!> Subtract a dense matrix from a block, e.g. block_matrix(row, column) -= dns_matrix.
+  subroutine subtract_from_block_zdns(block_matrix, dns_matrix, row, column)
+    !> The block matrix to subtract from.
+    type(TSquareBlockZDns), intent(inout) :: block_matrix
+    !> The dense matrix to subtract.
+    type(z_DNS), intent(in) :: dns_matrix
+    !> The row index of the block.
+    integer, intent(in) :: row
+    !> The column index of the block.
+    integer, intent(in) :: column
+
+    block_matrix%blocks(row, column)%val = block_matrix%blocks(row, column)%val - dns_matrix%val
+
+  end subroutine subtract_from_block_zdns
 
 end module ln_blockmat

--- a/src/ln_blockmat.F90
+++ b/src/ln_blockmat.F90
@@ -133,7 +133,7 @@ contains
     type(TSquareBlockZDns), intent(inout) :: this
     !> The CSR matrix to copy values from.
     type(z_CSR), intent(in) :: csr_matrix
-    !> The starting index of each box. The last index must be the final row + 1.
+    !> The starting index of each block. The last index must be the final row + 1.
     integer, dimension(:), allocatable, intent(in) :: indices
 
     integer :: i, nbl

--- a/src/ln_blockmat.F90
+++ b/src/ln_blockmat.F90
@@ -32,8 +32,12 @@ module ln_blockmat
 
 !> A square block matrix with blocks of type z_DNS.
   type TSquareBlockZDns
+    !> The array contaning the dense matrices
     type(z_DNS), dimension(:, :), allocatable :: blocks
+    !> The number of block (and column) rows
     integer :: nblocks = 0
+    !> The array with the starting index of each block row, including an
+    !> element nblock + 1 with the last row + 1.
     integer, dimension(:), allocatable :: blockind
   end type TSquareBlockZDns
 
@@ -105,7 +109,7 @@ contains
     integer nrow, ncol
 
     nrow = this%blockind(i + 1) - this%blockind(i)
-    ncol = this%blockind(i + 1) - this%blockind(i)
+    ncol = this%blockind(j + 1) - this%blockind(j)
 
     call create(this%blocks(i, j), nrow, ncol)
     this%blocks(i, j)%val = (0.d0, 0.d0)

--- a/src/ln_blockmat.F90
+++ b/src/ln_blockmat.F90
@@ -58,7 +58,7 @@ module ln_blockmat
 
 contains
 
-!> Create a block matrix. The individual blocks are not allocated here.
+  !> Create a block matrix. The individual blocks are not allocated here.
   subroutine create_blockmat_zdns(matrix, nrow)
     !> The matrix to be created.
     type(TSquareBlockZDns), intent(out) :: matrix
@@ -74,7 +74,7 @@ contains
 
   end subroutine create_blockmat_zdns
 
-!> Destroy a block matrix.
+  !> Destroy a block matrix.
   subroutine destroy_blockmat_zdns(matrix)
     !> The matrix to be created.
     type(TSquareBlockZDns), intent(out) :: matrix
@@ -86,8 +86,8 @@ contains
 
   end subroutine destroy_blockmat_zdns
 
-!> Initialize a tridiagonal block matrix with the same blocks
-!> as a sample one, but filled with zeros.
+  !> Initialize a tridiagonal block matrix with the same blocks
+  !> as a sample one, but filled with zeros.
   subroutine init_tridiagonal_blockmat_zdns(sample_matrix, matrix)
     !> The matrix which provides the tridiagonal blocks size
     type(TSquareBlockZDns), intent(in) :: sample_matrix
@@ -125,8 +125,8 @@ contains
 
   end subroutine init_tridiagonal_blockmat_zdns
 
-!> Convert a CSR matrix to a tridiagonal block square. Entries out of the
-!> tridiagonal blocks are ignored. The block matrix is constructed internally.
+  !> Convert a CSR matrix to a tridiagonal block square. Entries out of the
+  !> tridiagonal blocks are ignored. The block matrix is constructed internally.
   subroutine zcsr_to_tridiagonal_blockmat_zdns(csr_matrix, indices, block_matrix)
     !> The CSR matrix to copy values from.
     type(z_CSR), intent(in) :: csr_matrix
@@ -155,7 +155,7 @@ contains
 
   end subroutine zcsr_to_tridiagonal_blockmat_zdns
 
-!> Subtract a dense matrix from a block, e.g. block_matrix(row, column) -= dns_matrix.
+  !> Subtract a dense matrix from a block, e.g. block_matrix(row, column) -= dns_matrix.
   subroutine subtract_from_block_zdns(block_matrix, dns_matrix, row, column)
     !> The block matrix to subtract from.
     type(TSquareBlockZDns), intent(inout) :: block_matrix

--- a/src/ln_blockmat.F90
+++ b/src/ln_blockmat.F90
@@ -27,7 +27,7 @@ module ln_blockmat
   private
 
   public :: TSquareBlockZDns
-  public :: create_blockmat, destroy_blockmat, init_tridiagonal_blockmat, &
+  public :: create_blockmat, destroy_blockmat, create_tridiagonal_blockmat, &
             csr_to_tridiagonal_blockmat, subtract_from_block
 
 !> A square block matrix with blocks of type z_DNS.
@@ -44,8 +44,8 @@ module ln_blockmat
     module procedure destroy_blockmat_zdns
   end interface
 
-  interface init_tridiagonal_blockmat
-    module procedure init_tridiagonal_blockmat_zdns
+  interface create_tridiagonal_blockmat
+    module procedure create_tridiagonal_blockmat_zdns
   end interface
 
   interface csr_to_tridiagonal_blockmat
@@ -59,71 +59,71 @@ module ln_blockmat
 contains
 
   !> Create a block matrix. The individual blocks are not allocated here.
-  subroutine create_blockmat_zdns(matrix, nrow)
+  subroutine create_blockmat_zdns(this, nrow)
     !> The matrix to be created.
-    type(TSquareBlockZDns), intent(out) :: matrix
+    type(TSquareBlockZDns), intent(out) :: this
     !> The number of block rows.
     integer, intent(in) :: nrow
 
-    if (allocated(matrix%blocks)) then
-      call destroy_blockmat(matrix)
+    if (allocated(this%blocks)) then
+      call destroy_blockmat(this)
     end if
 
-    allocate (matrix%blocks(nrow, nrow))
-    matrix%nrow = nrow
+    allocate (this%blocks(nrow, nrow))
+    this%nrow = nrow
 
   end subroutine create_blockmat_zdns
 
   !> Destroy a block matrix.
-  subroutine destroy_blockmat_zdns(matrix)
+  subroutine destroy_blockmat_zdns(this)
     !> The matrix to be created.
-    type(TSquareBlockZDns), intent(out) :: matrix
+    type(TSquareBlockZDns), intent(inout) :: this
 
-    if (allocated(matrix%blocks)) then
-      deallocate (matrix%blocks)
+    if (allocated(this%blocks)) then
+      deallocate (this%blocks)
     end if
-    matrix%nrow = 0
+    this%nrow = 0
 
   end subroutine destroy_blockmat_zdns
 
   !> Initialize a tridiagonal block matrix with the same blocks
   !> as a sample one, but filled with zeros.
-  subroutine init_tridiagonal_blockmat_zdns(sample_matrix, matrix)
+  subroutine create_tridiagonal_blockmat_zdns(this, sample_matrix)
     !> The matrix which provides the tridiagonal blocks size
     type(TSquareBlockZDns), intent(in) :: sample_matrix
     !> The matrix to initialize
-    type(TSquareBlockZDns), intent(out) :: matrix
+    type(TSquareBlockZDns), intent(out) :: this
 
     integer :: nbl, j
 
-    call create_blockmat(matrix, sample_matrix%nrow)
+    call create_blockmat(this, sample_matrix%nrow)
 
     nbl = sample_matrix%nrow
 
     associate (bl => sample_matrix%blocks)
 
-      call create(matrix%blocks(1, 1), bl(1, 1)%nrow, bl(1, 1)%ncol)
-      matrix%blocks(1, 1)%val = (0.0_dp, 0.0_dp)
+      call create(this%blocks(1, 1), bl(1, 1)%nrow, bl(1, 1)%ncol)
+      this%blocks(1, 1)%val = (0.0_dp, 0.0_dp)
       do j = 2, nbl - 1
-        call create(matrix%blocks(j - 1, j), bl(j - 1, j)%nrow, bl(j - 1, j)%ncol)
-        matrix%blocks(j - 1, j)%val = (0.0_dp, 0.0_dp)
-        call create(matrix%blocks(j, j), bl(j, j)%nrow, bl(j, j)%ncol)
-        matrix%blocks(j, j)%val = (0.0_dp, 0.0_dp)
-        call create(matrix%blocks(j, j - 1), bl(j, j - 1)%nrow, bl(j, j - 1)%ncol)
-        matrix%blocks(j, j - 1)%val = (0.0_dp, 0.0_dp)
+        call create(this%blocks(j - 1, j), bl(j - 1, j)%nrow, bl(j - 1, j)%ncol)
+        this%blocks(j - 1, j)%val = (0.0_dp, 0.0_dp)
+        call create(this%blocks(j, j), bl(j, j)%nrow, bl(j, j)%ncol)
+        this%blocks(j, j)%val = (0.0_dp, 0.0_dp)
+        call create(this%blocks(j, j - 1), bl(j, j - 1)%nrow, bl(j, j - 1)%ncol)
+        this%blocks(j, j - 1)%val = (0.0_dp, 0.0_dp)
       end do
       if (nbl .gt. 1) then
-        call create(matrix%blocks(nbl, nbl), bl(nbl, nbl)%nrow, bl(nbl, nbl)%ncol)
-        matrix%blocks(nbl, nbl)%val = (0.0_dp, 0.0_dp)
-        call create(matrix%blocks(nbl - 1, nbl), bl(nbl - 1, nbl)%nrow, bl(nbl - 1, nbl)%ncol)
-        matrix%blocks(nbl - 1, nbl)%val = (0.0_dp, 0.0_dp)
-        call create(matrix%blocks(nbl, nbl - 1), bl(nbl, nbl - 1)%nrow, bl(nbl, nbl - 1)%ncol)
-        matrix%blocks(nbl, nbl - 1)%val = (0.0_dp, 0.0_dp)
+        call create(this%blocks(nbl, nbl), bl(nbl, nbl)%nrow, bl(nbl, nbl)%ncol)
+        this%blocks(nbl, nbl)%val = (0.0_dp, 0.0_dp)
+        call create(this%blocks(nbl - 1, nbl), bl(nbl - 1, nbl)%nrow, bl(nbl - 1, nbl)%ncol)
+        this%blocks(nbl - 1, nbl)%val = (0.0_dp, 0.0_dp)
+        call create(this%blocks(nbl, nbl - 1), bl(nbl, nbl - 1)%nrow, bl(nbl, nbl - 1)%ncol)
+        this%blocks(nbl, nbl - 1)%val = (0.0_dp, 0.0_dp)
       end if
 
     end associate
 
-  end subroutine init_tridiagonal_blockmat_zdns
+  end subroutine create_tridiagonal_blockmat_zdns
 
   !> Convert a CSR matrix to a tridiagonal block square. Entries out of the
   !> tridiagonal blocks are ignored. The block matrix is constructed internally.
@@ -137,9 +137,9 @@ contains
 
     integer :: i, nbl
 
-    call create_blockmat(block_matrix, csr_matrix%nrow)
-
     nbl = size(indices) - 1
+
+    call create_blockmat(block_matrix, nbl)
 
     do i = 1, nbl
       call extract(csr_matrix, indices(i), indices(i + 1) - 1, indices(i), &
@@ -156,9 +156,9 @@ contains
   end subroutine zcsr_to_tridiagonal_blockmat_zdns
 
   !> Subtract a dense matrix from a block, e.g. block_matrix(row, column) -= dns_matrix.
-  subroutine subtract_from_block_zdns(block_matrix, dns_matrix, row, column)
+  subroutine subtract_from_block_zdns(this, dns_matrix, row, column)
     !> The block matrix to subtract from.
-    type(TSquareBlockZDns), intent(inout) :: block_matrix
+    type(TSquareBlockZDns), intent(inout) :: this
     !> The dense matrix to subtract.
     type(z_DNS), intent(in) :: dns_matrix
     !> The row index of the block.
@@ -166,8 +166,90 @@ contains
     !> The column index of the block.
     integer, intent(in) :: column
 
-    block_matrix%blocks(row, column)%val = block_matrix%blocks(row, column)%val - dns_matrix%val
+    this%blocks(row, column)%val = this%blocks(row, column)%val - dns_matrix%val
 
   end subroutine subtract_from_block_zdns
+
+  !TODO: FINISH ME
+  !> Convert a block matrix to a CSR folowing a given non-zero values pattern
+  !> Note: this has been probably been used only on tri-diagonal matrices.
+  subroutine blockmat_to_masked_csr(G, indices, P, Gcsr)
+
+    type(z_DNS), dimension(:,:) :: G
+    integer, dimension(:), intent(in) :: indices
+    type(z_CSR) :: Gcsr
+    type(z_CSR) :: P, G_sp
+
+    integer :: nbl, oldx, row, col, iy, ix, x, y, ii, jj, nrows
+
+    nbl = size(indices)
+    nrows = indices(nbl) - 1
+
+    !create Gcsr with same pattern of P
+    call create(Gcsr,P%nrow,P%ncol,P%nnz)
+    Gcsr%rowpnt = P%rowpnt
+    Gcsr%colind = P%colind
+    Gcsr%nzval = (0.0_dp, 0.0_dp)
+
+    associate(indblk=>indices)
+    !Cycle upon all rows
+    x = 1
+    do ii = 1, nrows
+      !Search block x containing row ii
+      oldx = x
+      if (oldx.EQ.nbl) THEN
+        x = oldx
+      ELSE
+        do ix = oldx, oldx+1
+          if ( (ii.GE.indblk(ix)).AND.(ii.LT.indblk(ix+1)) ) x = ix
+        end do
+      endif
+
+      !Offset: row is the index for separate blocks
+      row = ii - indblk(x) + 1
+
+      !Cycle upon columns of Gcsr (which has been ALREADY MASKED by S)
+      do jj = Gcsr%rowpnt(ii), Gcsr%rowpnt(ii+1) -1
+        if (Gcsr%colind(jj).gt.nrows) CYCLE
+        !Choose which block column we're dealing with
+        y = 0
+        if (x.eq.1) then
+          if ( (Gcsr%colind(jj).GE.indblk(x)).AND.(Gcsr%colind(jj).LT.indblk(x + 1)) ) then
+            y = 1
+          ELSEif ( (Gcsr%colind(jj).GE.indblk(x + 1)).AND.(Gcsr%colind(jj).LT.indblk(x + 2)) ) then
+            y = 2
+          endif
+        elseif (x.eq.nbl) then
+          if ( (Gcsr%colind(jj).GE.indblk(x)).AND.(Gcsr%colind(jj).LT.indblk(x + 1)) ) then
+            y = nbl
+          ELSEif ( (Gcsr%colind(jj).GE.indblk(x - 1)).AND.(Gcsr%colind(jj).LT.indblk(x)) ) then
+            y = nbl - 1
+          endif
+        else
+          do iy = x-1, x+1
+            if ( (Gcsr%colind(jj).GE.indblk(iy)).AND.(Gcsr%colind(jj).LT.indblk(iy + 1)) ) y = iy
+          end do
+        endif
+
+        if (y.EQ.0) THEN
+          write(*,*)
+          write(*,*) 'ERROR in blk2csr: probably wrong PL size', x
+          write(*,*) 'row',ii,nrows,Gcsr%colind(jj)
+          write(*,*) 'block indeces:',indblk(1:nbl)
+          STOP
+        endif
+
+        col = Gcsr%colind(jj) - indblk(y) + 1
+
+        if (allocated(G(x,y)%val)) THEN
+          Gcsr%nzval(jj) = Gcsr%nzval(jj) + G(x,y)%val(row,col)
+        endif
+
+      end do
+
+    end do
+    end associate
+
+  end subroutine blockmat_to_masked_csr
 
 end module ln_blockmat

--- a/src/ln_blockmat.F90
+++ b/src/ln_blockmat.F90
@@ -18,96 +18,94 @@
 !!  <http://www.gnu.org/licenses/>.                                         !
 !!--------------------------------------------------------------------------!
 
-
 module ln_blockmat
   use ln_precision
   use ln_allocation
-  use mat_def, only : z_DNS, create, destroy
+  use mat_def, only: z_DNS, create, destroy
   implicit none
   private
 
-
-public :: TSquareBlockZDns
-public :: create_blockmat, destroy_blockmat, init_tridiagonal_blockmat
+  public :: TSquareBlockZDns
+  public :: create_blockmat, destroy_blockmat, init_tridiagonal_blockmat
 
 !> A square block matrix with blocks of type z_DNS.
-type TSquareBlockZDns
-   type(z_DNS), dimension(:,:), allocatable :: blocks
-   integer :: nrow = 0
-end type TSquareBlockZDns
+  type TSquareBlockZDns
+    type(z_DNS), dimension(:, :), allocatable :: blocks
+    integer :: nrow = 0
+  end type TSquareBlockZDns
 
-interface create_blockmat
-   module procedure create_blockmat_zdns
-end interface
+  interface create_blockmat
+    module procedure create_blockmat_zdns
+  end interface
 
-interface destroy_blockmat
-   module procedure destroy_blockmat_zdns
-end interface
+  interface destroy_blockmat
+    module procedure destroy_blockmat_zdns
+  end interface
 
-interface init_tridiagonal_blockmat
-   module procedure init_tridiagonal_blockmat_zdns
-end interface
+  interface init_tridiagonal_blockmat
+    module procedure init_tridiagonal_blockmat_zdns
+  end interface
 
 contains
 
 !> Create a block matrix. The individual blocks are not allocated here.
-subroutine create_blockmat_zdns(matrix, nrow)
-   !> The matrix to be created.
-   type(TSquareBlockZDns), intent(out) :: matrix
-   !> The number of block rows.
-   integer, intent(in) :: nrow
+  subroutine create_blockmat_zdns(matrix, nrow)
+    !> The matrix to be created.
+    type(TSquareBlockZDns), intent(out) :: matrix
+    !> The number of block rows.
+    integer, intent(in) :: nrow
 
-   allocate(matrix%blocks(nrow, nrow))
-   matrix%nrow = nrow
+    allocate (matrix%blocks(nrow, nrow))
+    matrix%nrow = nrow
 
-end subroutine create_blockmat_zdns
+  end subroutine create_blockmat_zdns
 
 !> Destroy a block matrix.
-subroutine destroy_blockmat_zdns(matrix)
-   !> The matrix to be created.
-   type(TSquareBlockZDns), intent(out) :: matrix
+  subroutine destroy_blockmat_zdns(matrix)
+    !> The matrix to be created.
+    type(TSquareBlockZDns), intent(out) :: matrix
 
-   if (allocated(matrix%blocks)) then
-      deallocate(matrix%blocks)
-   endif
-   matrix%nrow = 0
+    if (allocated(matrix%blocks)) then
+      deallocate (matrix%blocks)
+    endif
+    matrix%nrow = 0
 
-end subroutine destroy_blockmat_zdns
+  end subroutine destroy_blockmat_zdns
 
 !> Initialize a tridiagonal block matrix with the same blocks
 !> as a sample one, but filled with zeros.
-subroutine init_tridiagonal_blockmat_zdns(sample_matrix, matrix)
-   !> The matrix which provides the tridiagonal blocks size
-   type(TSquareBlockZDns), intent(in) :: sample_matrix
-   !> The matrix to initialize
-   type(TSquareBlockZDns), intent(out) :: matrix
+  subroutine init_tridiagonal_blockmat_zdns(sample_matrix, matrix)
+    !> The matrix which provides the tridiagonal blocks size
+    type(TSquareBlockZDns), intent(in) :: sample_matrix
+    !> The matrix to initialize
+    type(TSquareBlockZDns), intent(out) :: matrix
 
-   integer :: nbl, j
+    integer :: nbl, j
 
-   call destroy_blockmat(matrix)
-   call create_blockmat(matrix, sample_matrix%nrow)
+    call destroy_blockmat(matrix)
+    call create_blockmat(matrix, sample_matrix%nrow)
 
-   nbl = sample_matrix%nrow
+    nbl = sample_matrix%nrow
 
-   call create(matrix%blocks(1,1), sample_matrix%blocks(1,1)%nrow, sample_matrix%blocks(1,1)%ncol)
-   matrix%blocks(1,1)%val=(0.0_dp,0.0_dp)
-   do j=2,nbl-1
-      call create(matrix%blocks(j-1,j),sample_matrix%blocks(j-1,j)%nrow,sample_matrix%blocks(j-1,j)%ncol)
-      matrix%blocks(j-1,j)%val=(0.0_dp,0.0_dp)
-      call create(matrix%blocks(j,j),sample_matrix%blocks(j,j)%nrow,sample_matrix%blocks(j,j)%ncol)
-      matrix%blocks(j,j)%val=(0.0_dp,0.0_dp)
-      call create(matrix%blocks(j,j-1),sample_matrix%blocks(j,j-1)%nrow,sample_matrix%blocks(j,j-1)%ncol)
-      matrix%blocks(j,j-1)%val=(0.0_dp,0.0_dp)
-   end do
-   if (nbl.gt.1) then
-      call create(matrix%blocks(nbl,nbl),sample_matrix%blocks(nbl,nbl)%nrow,sample_matrix%blocks(nbl,nbl)%ncol)
-      matrix%blocks(nbl,nbl)%val=(0.0_dp,0.0_dp)
-      call create(matrix%blocks(nbl-1,nbl),sample_matrix%blocks(nbl-1,nbl)%nrow,sample_matrix%blocks(nbl-1,nbl)%ncol)
-      matrix%blocks(nbl-1,nbl)%val=(0.0_dp,0.0_dp)
-      call create(matrix%blocks(nbl,nbl-1),sample_matrix%blocks(nbl,nbl-1)%nrow,sample_matrix%blocks(nbl,nbl-1)%ncol)
-      matrix%blocks(nbl,nbl-1)%val=(0.0_dp,0.0_dp)
-   endif
+    call create(matrix%blocks(1, 1), sample_matrix%blocks(1, 1)%nrow, sample_matrix%blocks(1, 1)%ncol)
+    matrix%blocks(1, 1)%val = (0.0_dp, 0.0_dp)
+    do j = 2, nbl - 1
+      call create(matrix%blocks(j - 1, j), sample_matrix%blocks(j - 1, j)%nrow, sample_matrix%blocks(j - 1, j)%ncol)
+      matrix%blocks(j - 1, j)%val = (0.0_dp, 0.0_dp)
+      call create(matrix%blocks(j, j), sample_matrix%blocks(j, j)%nrow, sample_matrix%blocks(j, j)%ncol)
+      matrix%blocks(j, j)%val = (0.0_dp, 0.0_dp)
+      call create(matrix%blocks(j, j - 1), sample_matrix%blocks(j, j - 1)%nrow, sample_matrix%blocks(j, j - 1)%ncol)
+      matrix%blocks(j, j - 1)%val = (0.0_dp, 0.0_dp)
+    end do
+    if (nbl .gt. 1) then
+      call create(matrix%blocks(nbl, nbl), sample_matrix%blocks(nbl, nbl)%nrow, sample_matrix%blocks(nbl, nbl)%ncol)
+      matrix%blocks(nbl, nbl)%val = (0.0_dp, 0.0_dp)
+      call create(matrix%blocks(nbl - 1, nbl), sample_matrix%blocks(nbl - 1, nbl)%nrow, sample_matrix%blocks(nbl - 1, nbl)%ncol)
+      matrix%blocks(nbl - 1, nbl)%val = (0.0_dp, 0.0_dp)
+      call create(matrix%blocks(nbl, nbl - 1), sample_matrix%blocks(nbl, nbl - 1)%nrow, sample_matrix%blocks(nbl, nbl - 1)%ncol)
+      matrix%blocks(nbl, nbl - 1)%val = (0.0_dp, 0.0_dp)
+    endif
 
-end subroutine init_tridiagonal_blockmat_zdns
+  end subroutine init_tridiagonal_blockmat_zdns
 
 end module ln_blockmat

--- a/src/sparsekit_drv.F90
+++ b/src/sparsekit_drv.F90
@@ -242,14 +242,14 @@ MODULE sparsekit_drv
       logical, intent(in) :: sorted
       complex(dp) :: res
     end function zgetelm
-     
+
     subroutine dnscsr(nrow, ncol, nnz, aa, nr, bb, colind, rowpnt, ierr)
       import :: dp
       integer, intent(in) :: nrow, ncol
       integer, intent(inout) :: nnz
-      real(dp), intent(in) :: aa(*)  
+      real(dp), intent(in) :: aa(*)
       integer, intent(in) :: nr
-      real(dp), intent(inout) :: bb(*)  
+      real(dp), intent(inout) :: bb(*)
       integer, intent(inout) :: colind(*), rowpnt(*)
       integer, intent(inout) :: ierr
     end subroutine dnscsr
@@ -258,28 +258,28 @@ MODULE sparsekit_drv
       import :: dp
       integer, intent(in) :: nrow, ncol
       integer, intent(inout) :: nnz
-      complex(dp), intent(in) :: aa(*)  
+      complex(dp), intent(in) :: aa(*)
       integer, intent(in) :: nr
-      complex(dp), intent(inout) :: bb(*)  
+      complex(dp), intent(inout) :: bb(*)
       integer, intent(inout) :: colind(*), rowpnt(*)
       integer, intent(inout) :: ierr
     end subroutine zdnscsr
-       
+
     subroutine zcoocsr(nrow, nnz, aa, ia, ja, bb, jb, ib)
       import :: dp
       integer, intent(in) :: nrow, nnz
-      complex(dp), intent(in) :: aa(*)  
+      complex(dp), intent(in) :: aa(*)
       integer, intent(in) :: ia(*), ja(*)
       complex(dp), intent(inout) :: bb(*)
       integer, intent(inout) :: jb(*), ib(*)
     end subroutine zcoocsr
-    
+
     subroutine zcsrdns(nrow, ncol, aa, ja, ia, bb, nr, ierr)
       import :: dp
       integer, intent(in) :: nrow, ncol
-      complex(dp), intent(in) :: aa(*)  
+      complex(dp), intent(in) :: aa(*)
       integer, intent(in) :: ja(*), ia(*)
-      complex(dp), intent(inout) :: bb(*)  
+      complex(dp), intent(inout) :: bb(*)
       integer, intent(inout) :: nr
       integer, intent(inout) :: ierr
     end subroutine zcsrdns
@@ -287,14 +287,14 @@ MODULE sparsekit_drv
     subroutine zcsrcoo(nrow, job, nnz, aa, ja, ia, innz, bb, ib, jb, ierr)
       import :: dp
       integer, intent(in) :: nrow, job, nnz
-      complex(dp), intent(in) :: aa(*)  
+      complex(dp), intent(in) :: aa(*)
       integer, intent(in) :: ja(*), ia(*)
       integer, intent(inout) :: innz
-      complex(dp), intent(inout) :: bb(*)  
+      complex(dp), intent(inout) :: bb(*)
       integer, intent(inout) :: ib(*), jb(*)
       integer, intent(inout) :: ierr
     end subroutine zcsrcoo
-            
+
     subroutine zcsrcsc(nrow, job, ipos, aa, colind, rowpnt, bb, rowind, colpnt)
       import :: dp
       integer, intent(in) :: nrow, job, ipos
@@ -333,7 +333,7 @@ MODULE sparsekit_drv
       integer, intent(in) :: nnz
       integer, intent(inout) :: iw(*), ierr
     end subroutine zamub
-          
+
     subroutine zamubs(nrow, ncol, job, aa, ja, ia, s, bb, jb, ib, cc, jc, ic, nnz, iw, ierr)
       import :: dp
       integer, intent(in) :: nrow, ncol, job
@@ -345,7 +345,7 @@ MODULE sparsekit_drv
       integer, intent(in) :: nnz
       integer, intent(inout) :: iw(*), ierr
     end subroutine zamubs
-          
+
     subroutine aplb(nrow, ncol, job, aa, ja, ia, bb, jb, ib, cc, jc, ic, nnz, iw, ierr)
       import :: dp
       integer, intent(in) :: nrow, ncol, job
@@ -379,7 +379,7 @@ MODULE sparsekit_drv
       integer, intent(in) :: nnz
       integer, intent(inout) :: iw(*), ierr
     end subroutine zaplb
-    
+
     subroutine zaplsb(nrow, ncol, job, aa, ja, ia, s, bb, jb, ib, cc, jc, ic, nnz, iw, ierr)
       import :: dp
       integer, intent(in) :: nrow, ncol, job
@@ -402,7 +402,7 @@ MODULE sparsekit_drv
       integer, intent(in) :: nnz
       integer, intent(inout) :: ierr
     end subroutine zaplb1
-    
+
     subroutine zcplsamub(nrow, ncol, job, aa, ja, ia, s, bb, jb, ib, cc, jc, ic, nnz, iw, ierr)
       import :: dp
       integer, intent(in) :: nrow, ncol, job
@@ -421,7 +421,7 @@ MODULE sparsekit_drv
       complex(dp), intent(in) :: aa(*)
       integer, intent(in) :: ja(*), ia(*)
       integer, intent(inout) :: iw(*)
-      logical, intent(in) :: vals 
+      logical, intent(in) :: vals
     end subroutine zcsort
 
     subroutine ztransp(nrow,ncol,aa,ja,ia,iwk,ierr)
@@ -430,36 +430,36 @@ MODULE sparsekit_drv
       complex(dp), intent(inout) :: aa(*)
       integer, intent(inout) :: ja(*), ia(*)
       integer, intent(inout) :: iwk(*)
-      integer, intent(inout) :: ierr 
+      integer, intent(inout) :: ierr
     end subroutine ztransp
 
     subroutine zsubmat(nrow,job,i1,i2,j1,j2,aa,ja,ia,nr,nc,bb,jb,ib)
       import :: dp
-      integer, intent(in) :: nrow, job, i1, i2, j1, j2 
+      integer, intent(in) :: nrow, job, i1, i2, j1, j2
       complex(dp), intent(in) :: aa(*)
       integer, intent(in) :: ja(*), ia(*)
-      integer, intent(inout) :: nr, nc    
+      integer, intent(inout) :: nr, nc
       complex(dp), intent(inout) :: bb(*)
       integer, intent(inout) :: jb(*), ib(*)
     end subroutine zsubmat
 
     subroutine zcopmat(nrow,aa,ja,ia,bb,jb,ib,job,ierr)
       import :: dp
-      integer, intent(in) :: nrow 
+      integer, intent(in) :: nrow
       complex(dp), intent(in) :: aa(*)
       integer, intent(in) :: ja(*), ia(*)
       complex(dp), intent(inout) :: bb(*)
       integer, intent(inout) :: jb(*), ib(*)
       integer, intent(in) :: job, ierr
     end subroutine zcopmat
-  
+
     subroutine bandwidth(ncol, ja, ia, ml, mu, a_bw, bndav)
       import :: dp
-      integer, intent(in) :: ncol 
+      integer, intent(in) :: ncol
       integer, intent(in) :: ja(*), ia(*)
       integer, intent(inout) :: ml, mu, a_bw, bndav
     end subroutine bandwidth
-   
+
     !call zas1pls2b(A_csr%nrow,A_ncol,1,A_csr%nzval,A_csr%colind,A_csr%rowpnt,s1,s2,&
     !       B_csr%nzval,B_csr%colind,B_csr%rowpnt,C_csr%nzval,C_csr%colind,C_csr%rowpnt,&
     !       C_csr%nnz,iw,ierr)
@@ -478,7 +478,7 @@ MODULE sparsekit_drv
       integer, intent(inout) :: iw(*)
       integer, intent(inout) :: ierr
     end subroutine zas1pls2b
-      
+
     subroutine getdia(nrow, ncol, job, aa, ja, ia, len, dd, idiag, ioff)
       import :: dp
       integer, intent(in) :: nrow, ncol, job
@@ -489,7 +489,7 @@ MODULE sparsekit_drv
       integer, intent(inout) :: idiag(*)
       integer, intent(in) :: ioff
     end subroutine getdia
-    
+
     subroutine zgetdia(nrow, ncol, job, aa, ja, ia, len, dd, idiag, ioff)
       import :: dp
       integer, intent(in) :: nrow, ncol, job
@@ -503,7 +503,7 @@ MODULE sparsekit_drv
 
     !call ziluk(A_csr%nrow, A_csr%nzval, A_csr%colind, A_csr%rowpnt, lfil, &
     !     LU_msr%nzval, LU_msr%index, LU_ju, LU_levs, LU_iwk, w, jw, ierr)
-  end interface      
+  end interface
 
 CONTAINS
   ! -------------------------------------------------------------------------
@@ -2767,8 +2767,8 @@ CONTAINS
 
     IF ((i1.GT.i2).OR.(j1.GT.j2).OR.(i2.GT.A_csr%nrow).OR.(j2.GT.A_csr%ncol)) THEN
        print*, 'ERROR (zextract_csr): bad indeces specification';
-       print*, 'Trying to extract block from matrix',A_csr%nrow,'x',A_csr%ncol  
-       print*, 'Indices Rows',i1,i2,'Cols',j1,j2  
+       print*, 'Trying to extract block from matrix',A_csr%nrow,'x',A_csr%ncol
+       print*, 'Indices Rows',i1,i2,'Cols',j1,j2
        STOP
     ENDIF
 
@@ -2796,9 +2796,9 @@ CONTAINS
 
     IF ((i1.GT.i2).OR.(j1.GT.j2).OR.(i2.GT.A_csr%nrow).OR.(j2.GT.A_csr%ncol)) THEN
        print*, 'ERROR (zextract_dns): bad indeces specification';
-       print*, 'Trying to extract block from matrix',A_csr%nrow,'x',A_csr%ncol  
-       print*, 'Indices Rows',i1,i2,'Cols',j1,j2  
-       STOP 
+       print*, 'Trying to extract block from matrix',A_csr%nrow,'x',A_csr%ncol
+       print*, 'Indices Rows',i1,i2,'Cols',j1,j2
+       STOP
     ENDIF
 
     call create(A_dns,(i2-i1+1),(j2-j1+1))
@@ -3429,7 +3429,7 @@ CONTAINS
     complex(dp) :: trace
 
     integer :: i
-    
+
     trace = (0.d0,0.d0)
     if (present(mask)) then
        if (size(mask) /= mat%nrow) then
@@ -3438,7 +3438,7 @@ CONTAINS
        do i = 1,mat%nrow
           if (mask(i)) then
              trace = trace + mat%val(i,i)
-          end if   
+          end if
        end do
     else
        do i = 1,mat%nrow


### PR DESCRIPTION
This is not ready for merge, I am opening a PR as basis for discussion. I am trying to see if refactoring all block dense operations in the module iterative makes it more readable and easier to work with.
I defined a type for square block matrices and all related operations should go there. This type should be used for ESH, Gr, Gn (in principle it could also be used fir Sigma, Gamma etc. if it makes things more readable).
Operations like `Gr_ij X_j Ga_jk` or similar would be defined there. So bits like this which appears often:

```
call prealloc_mult(Gr(i-1,cb),Gam,work1)
call zdagger(Gr(i,cb),Ga)
call prealloc_mult(work1,Ga,frmdiff,Gn(i-1,i))
call destroy(work1)
```
will be refactored in a call. Also the block indices are known by the block matrix itself instead of passing all the time the structure negf%str

Most places where %blocks appears for ESH would go because this type would be used all over. 

In principle also the book keeping about 0 blocks could go there. 