### PR TITLE
Fix for transmission only cases

### DIFF
--- a/src/libnegf.F90
+++ b/src/libnegf.F90
@@ -1139,7 +1139,7 @@ contains
   subroutine destroy_surface_green_cache(negf)
     type(Tnegf) :: negf
 
-    call negf%surface_green_cache%destroy()
+    if (allocated(negf%surface_green_cache)) call negf%surface_green_cache%destroy()
 
   end subroutine destroy_surface_green_cache
 
@@ -1298,12 +1298,14 @@ contains
     type(Tnegf) :: negf
     integer :: i
 
-    do i = 1, size(negf%cont)
-       if (allocated(negf%cont(i)%HC%val)) call destroy(negf%cont(i)%HC)
-       if (allocated(negf%cont(i)%SC%val)) call destroy(negf%cont(i)%SC)
-       if (allocated(negf%cont(i)%HMC%val)) call destroy(negf%cont(i)%HMC)
-       if (allocated(negf%cont(i)%SMC%val)) call destroy(negf%cont(i)%SMC)
-    enddo
+    if (allocated(negf%cont)) then
+       do i = 1, size(negf%cont)
+          if (allocated(negf%cont(i)%HC%val)) call destroy(negf%cont(i)%HC)
+          if (allocated(negf%cont(i)%SC%val)) call destroy(negf%cont(i)%SC)
+          if (allocated(negf%cont(i)%HMC%val)) call destroy(negf%cont(i)%HMC)
+          if (allocated(negf%cont(i)%SMC%val)) call destroy(negf%cont(i)%SMC)
+       enddo
+    end if
 
   end subroutine destroy_matrices
 


### PR DESCRIPTION
As various data structures would not have been allocated unless
the GF is being calculated.

Closes #55